### PR TITLE
Feature/fix warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MPL-2.0
+# See https://spec.editorconfig.org/
+# See https://editorconfig.org/
+
+root = true
+
+# Rules for all files
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+spelling_language = en-US
+
+# Rules for C and C++ source files
+[*.{c, h, cpp, hpp}]
+indent_style = space
+indent_size = 4
+# Do not specify line endings since git's checkout will set to system's native value
+end_of_line = unset
+
+# Microsoft resource files
+[*.rc]
+indent_style = space
+indent_size = 4
+charset = utf-8-bom
+end_of_line = crlf
+
+# Rules for Makefiles
+[Makefile,GNUMakefile,GNUmakefile,Makefile.gccWin]
+indent_style = tab
+end_of_line = lf
+
+# Shell script rules
+[*.sh]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+
+# Batch files
+[*.{bat, cmd}]
+end_of_line = crlf
+charset = utf-8-bom
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# Powershell scripts
+[*.ps1]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8-bom
+
+# Clang format and tidy configuration files
+[.clang-format]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+
+[.clang-tidy]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+
+# Configuration/CI/YAML/JSON/XML files
+[*.{yaml,yml,xml,json,whitesource,ini,cfg,toml,conf}]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+
+# Markdown files
+[*.md]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = false
+
+# Git configuration files
+[.{gitattributes,gitignore,gitmodules}]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+
+# Generic text files
+[*.txt]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = crlf   # For Windows compatibility when editors don't understand unix line endings
+
+# Visual studio
+[*.{vcxproj,csproj,sln,vcxproj.filters}]
+indent_style = space
+indent_size = 2
+charset = utf-8-bom
+end_of_line = crlf
+
+# UEFI build files
+[*.{dec,dsc,inf}]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+
+# Python files
+[*.py]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+
+# Meson build files
+[meson.build,meson_options.txt,meson.options]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+max_line_length = 120
+insert_final_newline = true
+tab_width = 4
+
+# Meson subproject wrappers
+[*.wrap]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8

--- a/JSONOptions.h
+++ b/JSONOptions.h
@@ -8,7 +8,7 @@
 
 
 /*
- *  JSON_LIBRARY must be declared if libjson is compiled as a static or dynamic 
+ *  JSON_LIBRARY must be declared if libjson is compiled as a static or dynamic
  *  library.  This exposes a C-style interface, but none of the inner workings of libjson
  */
 #define JSON_LIBRARY
@@ -21,9 +21,9 @@
 
 
 /*
- *  JSON_DEBUG is used to perform extra error checking.  Because libjson usually 
+ *  JSON_DEBUG is used to perform extra error checking.  Because libjson usually
  *  does on the fly parsing, validation is impossible, so this option will allow
- *  you to register an error callback so that you can record what is going wrong 
+ *  you to register an error callback so that you can record what is going wrong
  *  before the library crashes.  This option does not protect from these errors,
  *  it simply tells you about them, which is nice for debugging, but not preferable
  *  for release candidates
@@ -43,11 +43,11 @@
  *  from the errors that it encounters.  This option is recommended for those who
  *  feel it's possible for their program to encounter invalid json.
  */
-#define JSON_SAFE
+//#define JSON_SAFE
 
 
 /*
- *  JSON_STDERROR routes error messages to cerr instead of a callback, this 
+ *  JSON_STDERROR routes error messages to cerr instead of a callback, this
  *  option hides the callback registering function.  This will usually display
  *  messages in the console
  */
@@ -113,7 +113,7 @@
 
 
 /*
- *  JSON_STREAM turns on libjson's streaming functionality.  This allows you to give parts of 
+ *  JSON_STREAM turns on libjson's streaming functionality.  This allows you to give parts of
  *  your json into a stream, which will automatically hit a callback when full nodes are
  *  completed
  */
@@ -141,7 +141,7 @@
 /*
  *	JSON_MEMORY_POOL Turns on libjson's iteraction with mempool++.  It is more efficient that simply
  *	connecting mempool++ to the callbacks because it integrates things internally and uses a number
- *	of memory pools.  This value tells libjson how large of a memory pool to start out with.  500KB 
+ *	of memory pools.  This value tells libjson how large of a memory pool to start out with.  500KB
  *	should suffice for most cases.  libjson will distribute that within the pool for the best
  *	performance depending on other settings.
  */
@@ -150,7 +150,7 @@
 
 /*
  *  JSON_MUTEX_CALLBACKS exposes functions to register callbacks to lock and unlock
- *  mutexs and functions to lock and unlock JSONNodes and all of it's children.  This 
+ *  mutexs and functions to lock and unlock JSONNodes and all of it's children.  This
  *  does not prevent other threads from accessing the node, but will prevent them from
  *  locking it. It is much easier for the end programmer to allow libjson to manage
  *  your mutexs because of reference counting and manipulating trees, libjson automatically
@@ -179,6 +179,24 @@
  */
 //#define JSON_OCTAL
 
+#ifndef JSON_PRIORITY_LOW
+#define JSON_PRIORITY_LOW 0
+#endif
+#ifndef JSON_PRIORITY_MED
+#define JSON_PRIORITY_MED 1
+#endif
+#ifndef JSON_PRIORITY_HIGH
+#define JSON_PRIORITY_HIGH 2
+#endif
+#ifndef LOW
+#define LOW JSON_PRIORITY_LOW
+#endif
+#ifndef MED
+#define MED JSON_PRIORITY_MED
+#endif
+#ifndef HIGH
+#define HIGH JSON_PRIORITY_HIGH
+#endif
 
 /*
  *  JSON_WRITE_PRIORITY turns on libjson's writing capabilties.  Without this libjson can only
@@ -197,7 +215,7 @@
 
 /*
  *  JSON_NEWLINE affects how libjson writes.  If this option is turned on, libjson
- *  will use whatever it's defined as for the newline signifier, otherwise, it will use 
+ *  will use whatever it's defined as for the newline signifier, otherwise, it will use
  *  standard unix \n.
  */
 //#define JSON_NEWLINE "\r\n"  //\r\n is standard for most windows and dos programs
@@ -244,7 +262,7 @@
 
 /*
  *  JSON_ARRAY_SIZE_ON_ON_LINE allows you to put small arrays of primitives all on one line
- *  in a write_formatted.  This is common for tuples, like coordinates.  If must be defined 
+ *  in a write_formatted.  This is common for tuples, like coordinates.  If must be defined
  *  as an integer
  */
 //#define JSON_ARRAY_SIZE_ON_ONE_LINE 2
@@ -264,7 +282,7 @@
 
 
 /*
- *  JSON_INDEX_TYPE allows you th change the size type for the children functions. If this 
+ *  JSON_INDEX_TYPE allows you th change the size type for the children functions. If this
  *  option is not used then unsigned int is used.  This option is useful for cutting down
  *  on memory, or using huge numbers of child nodes (over 4 billion)
  */
@@ -273,7 +291,7 @@
 
 /*
  *  JSON_BOOL_TYPE lets you change the bool type for the C interface.  Because before C99 there
- *  was no bool, and even then it's just a typedef, you may want to use something else.  If this 
+ *  was no bool, and even then it's just a typedef, you may want to use something else.  If this
  *  is not defined, it will revert to int
  */
 //#define JSON_BOOL_TYPE char
@@ -321,13 +339,13 @@
  *  compatibility between major releases.  It is highly recommended that you move your functions
  *  over to the new equivalents
  */
-#define JSON_DEPRECATED_FUNCTIONS
+// #define JSON_DEPRECATED_FUNCTIONS
 
 
 /*
  *  JSON_CASTABLE allows you to call as_bool on a number and have it do the 0 or not 0 check,
  *  it also allows you to ask for a string from a number, or boolean, and have it return the right thing.
- *  Without this option, those types of requests are undefined.  It also exposes the as_array, as_node, and cast 
+ *  Without this option, those types of requests are undefined.  It also exposes the as_array, as_node, and cast
  *  functions
  */
 #define JSON_CASTABLE

--- a/_internal/Dependencies/libbase64++/libbase64++.h
+++ b/_internal/Dependencies/libbase64++/libbase64++.h
@@ -2,6 +2,7 @@
 #define LIBBASE64_CPP_H
 
 #include <string>
+#include <array>
 //#define LIBBASE64_THROW_STD_INVALID_ARGUMENT
 
 //version info
@@ -18,11 +19,11 @@
 #else
 	#include <iostream>
 	#define LIBBASE64_ASSERT(cond, msg) if (!(cond)){ std::cerr << msg << std::endl; throw false; }
-	
+
 	template<typename T>
 	class libbase64_boundChecker {
 	public:
-		libbase64_boundChecker(const T * lbound, const T * ubound) : upperbound(ubound), lowerbound(lbound){};
+		libbase64_boundChecker(const T * lbound, const T * ubound) : lowerbound(lbound), upperbound(ubound) {}
 		T getLocation(const T * loc){
 			LIBBASE64_ASSERT(loc < upperbound, "Array index above bounds");
 			LIBBASE64_ASSERT(loc >= lowerbound, "Array index below bounds");
@@ -34,7 +35,7 @@
 	};
 	#define CREATEBOUNDCHECKER(type, name, ubound, lbound) libbase64_boundChecker<type> name(ubound, lbound)
 	#define GETITEM_BOUNDCHECK(loc, name) name.getLocation(loc)
-	
+
 	#ifdef LIBBASE64CODECOVERAGE
 		#define LIBBASE64CODECOVERAGEBRANCH { static bool f_codeCoverage_ = false; if (f_codeCoverage_ == false){ libbase64::getCoverageHits<STRINGTYPE, CHARTYPE, UCHARTYPE, SAFETY>(true); f_codeCoverage_ = true; } }
 	#endif
@@ -66,34 +67,36 @@ namespace libbase64 {
 			return hits;
 		}
 	#endif
-	
+
 	//characters used in convertions
 	namespace libbase64_characters {
 		template<typename T>
 		inline static const T * getChar64(void){
-			static const T char64s[64] = {
+				static const std::array<T, 65> char64s = {{
 				(T)'A', (T)'B', (T)'C', (T)'D', (T)'E', (T)'F', (T)'G', (T)'H', (T)'I', (T)'J', (T)'K', (T)'L', (T)'M',
 				(T)'N', (T)'O', (T)'P', (T)'Q', (T)'R', (T)'S', (T)'T', (T)'U', (T)'V', (T)'W', (T)'X', (T)'Y', (T)'Z',
 				(T)'a', (T)'b', (T)'c', (T)'d', (T)'e', (T)'f', (T)'g', (T)'h', (T)'i', (T)'j', (T)'k', (T)'l', (T)'m',
 				(T)'n', (T)'o', (T)'p', (T)'q', (T)'r', (T)'s', (T)'t', (T)'u', (T)'v', (T)'w', (T)'x', (T)'y', (T)'z',
-				(T)'0', (T)'1', (T)'2', (T)'3', (T)'4', (T)'5', (T)'6', (T)'7', (T)'8', (T)'9', (T)'+', (T)'/'
-			};
-			return char64s;
+				(T)'0', (T)'1', (T)'2', (T)'3', (T)'4', (T)'5', (T)'6', (T)'7', (T)'8', (T)'9', (T)'+', (T)'/', (T)'\0'
+			}};
+			static_assert(char64s.size() == 65, "Conversion table must be 65 to NULL terminate. This may be passed to functions expecting a null terminated C string which require this character to work properly");
+			return char64s.data();
 		}
-		
+
+
 		template<typename T>
 		inline static T getChar(unsigned char bin){
 			CREATEBOUNDCHECKER(T, char64bounds, getChar64<T>(), getChar64<T>() + 64);
 			return GETITEM_BOUNDCHECK(getChar64<T>() + bin, char64bounds);
 		}
-		
+
 		template<typename T>
 		inline static T toBinary(T c) {
 			static T binaryConvert[80] = {62,48,49,50,63,52,53,54,55,56,57,58,59,60,61,249,250,251,252,253,254,255,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 			CREATEBOUNDCHECKER(T, binaryConvertsbounds, binaryConvert, binaryConvert + 80);
 			return GETITEM_BOUNDCHECK(binaryConvert + c - 43, binaryConvertsbounds);
 		}
-		
+
 		template<typename T>
 		static inline T & emptyString(void){
 			static T t;
@@ -116,8 +119,8 @@ namespace libbase64 {
 	 */
 	template<class STRINGTYPE, typename CHARTYPE, typename UCHARTYPE, bool SAFETY>
 	static STRINGTYPE encode(const unsigned char * binary, size_t bytes){
-		CREATEBOUNDCHECKER(unsigned char, binarybounds, binary, binary + bytes);	
-	
+		CREATEBOUNDCHECKER(unsigned char, binarybounds, binary, binary + bytes);
+
 		//make sure that there is actually something to encode
 		if (SAFETY){
 			if (libbase64_unlikely(bytes == 0)){
@@ -125,22 +128,29 @@ namespace libbase64 {
 				return libbase64_characters::emptyString<STRINGTYPE>();
 			}
 		}
-		
+
 		//calculate length and how misaligned it is
 		size_t misaligned = bytes % 3;
 		STRINGTYPE result;
 		result.reserve(libbase64_Calculator::getEncodingSize(bytes));
-		
+
 		//do all of the ones that are 3 byte aligned
 		for (size_t i = 0, aligned((bytes - misaligned) / 3); i < aligned; ++i){
 			LIBBASE64CODECOVERAGEBRANCH;
-			result += libbase64_characters::getChar<CHARTYPE>((GETITEM_BOUNDCHECK(binary, binarybounds) & 0xFC) >> 2);
-			result += libbase64_characters::getChar<CHARTYPE>(((GETITEM_BOUNDCHECK(binary, binarybounds) & 0x03) << 4) + ((GETITEM_BOUNDCHECK(binary + 1, binarybounds) & 0xF0) >> 4));
-			result += libbase64_characters::getChar<CHARTYPE>(((GETITEM_BOUNDCHECK(binary + 1, binarybounds) & 0x0F) << 2) + ((GETITEM_BOUNDCHECK(binary + 2, binarybounds) & 0xC0) >> 6));
-			result += libbase64_characters::getChar<CHARTYPE>(GETITEM_BOUNDCHECK(binary + 2, binarybounds) & 0x3F);
+				// compute indices as UCHARTYPE then fetch characters as CHARTYPE to avoid implicit sign conversions
+				{
+					const UCHARTYPE idx0 = static_cast<UCHARTYPE>(((GETITEM_BOUNDCHECK(binary, binarybounds) & 0xFC) >> 2));
+					const UCHARTYPE idx1 = static_cast<UCHARTYPE>((((GETITEM_BOUNDCHECK(binary, binarybounds) & 0x03) << 4) + ((GETITEM_BOUNDCHECK(binary + 1, binarybounds) & 0xF0) >> 4)));
+					const UCHARTYPE idx2 = static_cast<UCHARTYPE>((((GETITEM_BOUNDCHECK(binary + 1, binarybounds) & 0x0F) << 2) + ((GETITEM_BOUNDCHECK(binary + 2, binarybounds) & 0xC0) >> 6)));
+					const UCHARTYPE idx3 = static_cast<UCHARTYPE>((GETITEM_BOUNDCHECK(binary + 2, binarybounds) & 0x3F));
+					result += libbase64_characters::getChar<CHARTYPE>(static_cast<unsigned char>(idx0));
+					result += libbase64_characters::getChar<CHARTYPE>(static_cast<unsigned char>(idx1));
+					result += libbase64_characters::getChar<CHARTYPE>(static_cast<unsigned char>(idx2));
+					result += libbase64_characters::getChar<CHARTYPE>(static_cast<unsigned char>(idx3));
+				}
 			binary += 3;
 		}
-		
+
 		//handle any additional characters at the end of it
 		if (libbase64_likely(misaligned != 0)){
 			LIBBASE64CODECOVERAGEBRANCH;
@@ -150,7 +160,7 @@ namespace libbase64 {
 				LIBBASE64CODECOVERAGEBRANCH;
 				temp[i] = GETITEM_BOUNDCHECK(binary++, binarybounds);
 			}
-			
+
 			//now do the final three bytes
 			result += libbase64_characters::getChar<CHARTYPE>((temp[0] & 0xFC) >> 2);
 			result += libbase64_characters::getChar<CHARTYPE>(((temp[0] & 0x03) << 4) + ((temp[1] & 0xF0) >> 4));
@@ -165,16 +175,16 @@ namespace libbase64 {
 		} else {
 			LIBBASE64CODECOVERAGEBRANCH;
 		}
-		
+
 		LIBBASE64_ASSERT(libbase64_Calculator::getEncodingSize(bytes) == result.length(), "Reserve wasn't the correct guess");
 		return result;
-	}	
-		
+	}
+
 	template<class STRINGTYPE, typename CHARTYPE, typename UCHARTYPE, bool SAFETY>
     static std::string decode(const STRINGTYPE & encoded){
 		//check length to be sure its acceptable for base64
 		const size_t length = encoded.length();
-		
+
 		if (SAFETY){
 			if (libbase64_unlikely((length % 4) != 0)){
 				LIBBASE64CODECOVERAGEBRANCH;
@@ -184,7 +194,7 @@ namespace libbase64 {
 				LIBBASE64CODECOVERAGEBRANCH;
 				return libbase64_characters::emptyString<std::string>();
 			}
-			
+
 			//check to be sure there aren't odd characters or characters in the wrong places
 			size_t pos = encoded.find_first_not_of(libbase64_characters::getChar64<CHARTYPE>());
 			if (libbase64_unlikely(pos != STRINGTYPE::npos)){
@@ -223,7 +233,7 @@ namespace libbase64 {
 				LIBBASE64CODECOVERAGEBRANCH;
 			}
 		}
-		
+
 		const CHARTYPE * runner = encoded.data();
 		const CHARTYPE * end = runner + encoded.length();
 		CREATEBOUNDCHECKER(CHARTYPE, encodedbounds, runner, end);
@@ -231,36 +241,38 @@ namespace libbase64 {
 		std::string result;
 		--aligned;
 		result.reserve(libbase64_Calculator::getDecodingSize(length));
-		
+
 		//first do the ones that can not have any padding
 		for (unsigned int i = 0; i < aligned; ++i){
-			const CHARTYPE second = libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 1, encodedbounds));
-			const CHARTYPE third = libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 2, encodedbounds));
-			result += (libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds)) << 2) + ((second & 0x30) >> 4);
-			result += ((second & 0xf) << 4) + ((third & 0x3c) >> 2);
-			result += ((third & 0x3) << 6) + libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 3, encodedbounds));
+				// cast encoded chars to UCHARTYPE before converting to binary to avoid signed->unsigned warnings
+				const UCHARTYPE second = libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 1, encodedbounds)));
+				const UCHARTYPE third = libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 2, encodedbounds)));
+				const UCHARTYPE first = libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds)));
+				result += static_cast<CHARTYPE>((first << 2) + ((second & 0x30) >> 4));
+				result += static_cast<CHARTYPE>(((second & 0xf) << 4) + ((third & 0x3c) >> 2));
+				result += static_cast<CHARTYPE>(((third & 0x3) << 6) + libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 3, encodedbounds))));
 			runner += 4;
 		}
-		
+
 		//now do the ones that might have padding, the first two characters can not be padding, so do them quickly
-		const CHARTYPE second = libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 1, encodedbounds));
-		result += (libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 0, encodedbounds)) << 2) + ((second & 0x30) >> 4);
+		const UCHARTYPE second = libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 1, encodedbounds)));
+		result += static_cast<CHARTYPE>((libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner + 0, encodedbounds))) << 2) + ((second & 0x30) >> 4));
 		runner += 2;
 		if ((runner != end) && (*runner != (CHARTYPE)'=')){  //not two = pads
 			LIBBASE64CODECOVERAGEBRANCH;
-			const CHARTYPE third = libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds));
-			result += ((second & 0xf) << 4) + ((third & 0x3c) >> 2);
+				const UCHARTYPE third = libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds)));
+				result += static_cast<CHARTYPE>(((second & 0xf) << 4) + ((third & 0x3c) >> 2));
 			++runner;
 			if ((runner != end) && (*runner != (CHARTYPE)'=')){  //no padding
 				LIBBASE64CODECOVERAGEBRANCH;
-				result += ((third & 0x3) << 6) + libbase64_characters::toBinary<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds));
+					result += static_cast<CHARTYPE>(((third & 0x3) << 6) + libbase64_characters::toBinary<UCHARTYPE>(static_cast<UCHARTYPE>(GETITEM_BOUNDCHECK(runner, encodedbounds))));
 			} else {
 				LIBBASE64CODECOVERAGEBRANCH;
 			}
 		} else {
 			LIBBASE64CODECOVERAGEBRANCH;
 		}
-		
+
 		LIBBASE64_ASSERT(libbase64_Calculator::getDecodingSize(length) >= result.length(), "Reserve wasn't the correct guess, too small");
 		LIBBASE64_ASSERT((result.length() <= 3) || (libbase64_Calculator::getDecodingSize(length) > result.length() - 3), "Reserve wasn't the correct guess, too big");
 		return result;

--- a/_internal/Source/JSONAllocator.h
+++ b/_internal/Source/JSONAllocator.h
@@ -39,34 +39,34 @@ public:
 	typedef const T&  const_reference;
 	typedef T         value_type;
 	template <class U> struct rebind { typedef json_allocator<U> other; };
-	
-	//LIBJSON_OBJECT(json_allocator);
-	
-	inline json_allocator() json_nothrow { 
-		//LIBJSON_CTOR; 
+
+	//LIBJSON_OBJECT(json_allocator)
+
+	inline json_allocator() json_nothrow {
+		//LIBJSON_CTOR;
 	}
-	inline json_allocator(const json_allocator&) json_nothrow { 
-		//LIBJSON_COPY_CTOR; 
+	inline json_allocator(const json_allocator&) json_nothrow {
+		//LIBJSON_COPY_CTOR;
 	}
-	template <class U> inline json_allocator(const json_allocator<U>&) json_nothrow { 
-		//LIBJSON_COPY_CTOR; 
+	template <class U> inline json_allocator(const json_allocator<U>&) json_nothrow {
+		//LIBJSON_COPY_CTOR;
 	}
-	inline ~json_allocator() json_nothrow { 
-		//LIBJSON_DTOR; 
+	inline ~json_allocator() json_nothrow {
+		//LIBJSON_DTOR;
 	}
-	
+
 	inline pointer address(reference x) const { return &x; }
 	inline const_pointer address(const_reference x) const { return &x; }
-	
+
 	inline pointer allocate(size_type n, json_allocator<void>::const_pointer = 0) json_hot {
 		return (pointer)JSONAllocatorRelayer::alloc(n * sizeof(T));
 	}
 	inline void deallocate(pointer p, size_type) json_hot {
 		JSONAllocatorRelayer::dealloc(p);
 	}
-	
+
 	inline size_type max_size() const json_nothrow { return 0xEFFFFFFF; }
-	
+
 	inline void construct(pointer p, const T& val){
 		new(p)T(val);
 	};

--- a/_internal/Source/JSONChildren.cpp
+++ b/_internal/Source/JSONChildren.cpp
@@ -87,8 +87,9 @@ void jsonChildren::doerase(JSONNode ** position, json_index_t number) json_nothr
 	   #ifndef JSON_ISO_STRICT
 		  JSON_ASSERT((long long)position - (long long)array >= 0, JSON_TEXT("doing negative allocation"));
 	   #endif
-    } else {
-	   std::memmove(position, position + number, (mysize - (position - array) - number) * sizeof(JSONNode *));
-	   mysize -= number;
-    }
+	} else {
+		 const size_t cnt = static_cast<size_t>(mysize) - static_cast<size_t>(reinterpret_cast<uintptr_t>(position) - (reinterpret_cast<uintptr_t>(array))) - static_cast<size_t>(number);
+		 std::memmove(position, position + number, cnt * sizeof(JSONNode *));
+		 mysize -= number;
+	 }
 }

--- a/_internal/Source/JSONChildren.h
+++ b/_internal/Source/JSONChildren.h
@@ -4,6 +4,8 @@
 #include "JSONMemory.h"
 #include "JSONDebug.h"  //for JSON_ASSERT macro
 
+#include <inttypes.h>  //for uintptr_t
+
 #ifdef JSON_LESS_MEMORY
     #ifdef __GNUC__
 	   #pragma pack(push, 1)
@@ -36,7 +38,7 @@ class JSONNode;  //forward declaration
 
 class jsonChildren {
 public:
-	LIBJSON_OBJECT(jsonChildren);
+	LIBJSON_OBJECT(jsonChildren)
     //starts completely empty and the array is not allocated
     jsonChildren(void) json_nothrow : array(0), mysize(0), mycapacity(0) {
 	   LIBJSON_CTOR;
@@ -130,9 +132,9 @@ public:
 	template <bool reverse>
     struct iteratorKeeper {
     public:
-		LIBJSON_OBJECT(jsonChildren::iteratorKeeper);
-	  iteratorKeeper(jsonChildren * pthis, JSONNode ** & position) json_nothrow :
-		 myRelativeOffset(reverse ? (json_index_t)(pthis -> array + (size_t)pthis -> mysize - position) : (json_index_t)(position - pthis -> array)),
+		LIBJSON_OBJECT(jsonChildren::iteratorKeeper)
+		iteratorKeeper(jsonChildren * pthis, JSONNode ** & position) json_nothrow :
+			myRelativeOffset(reverse ? (json_index_t)(static_cast<json_index_t>(reinterpret_cast<uintptr_t>(pthis->array + static_cast<size_t>(pthis->mysize)) - reinterpret_cast<uintptr_t>(position))) : (json_index_t)(static_cast<json_index_t>(reinterpret_cast<uintptr_t>(position) - reinterpret_cast<uintptr_t>(pthis->array)))),
 		 myChildren(pthis),
 		 myPos(position){
 			LIBJSON_CTOR;
@@ -161,7 +163,7 @@ public:
 	   JSON_ASSERT(array != 0, JSON_TEXT("erasing something from a null array 1"));
 	   JSON_ASSERT(position >= array, JSON_TEXT("position is beneath the start of the array 1"));
 	   JSON_ASSERT(position <= array + mysize, JSON_TEXT("erasing out of bounds 1"));
-	   std::memmove(position, position + 1, (mysize-- - (position - array) - 1) * sizeof(JSONNode *));
+	   std::memmove(position, position + 1, (static_cast<size_t>(mysize--) - static_cast<size_t>(reinterpret_cast<uintptr_t>(position) - reinterpret_cast<uintptr_t>(array)) - 1) * sizeof(JSONNode *));
 	   iteratorKeeper<false> ik(this, position);
 	   shrink();
     }
@@ -196,14 +198,14 @@ public:
 		if (reverse){
 			iteratorKeeper<true> ik(this, position);
 			inc();
-		} else 
+		} else
 		#endif
 		{
 			iteratorKeeper<false> ik(this, position);
 			inc();
 		}
 
-	   std::memmove(position + 1, position, (mysize++ - (position - array)) * sizeof(JSONNode *));
+	std::memmove(position + 1, position, (static_cast<size_t>(mysize++) - static_cast<size_t>(reinterpret_cast<uintptr_t>(position) - reinterpret_cast<uintptr_t>(array))) * sizeof(JSONNode *));
 	   *position = item;
     }
 
@@ -215,7 +217,7 @@ public:
 		  iteratorKeeper<false> ik(this, position);
 		  inc(num);
 	   }
-	   const size_t ptrs = ((JSONNode **)(array + mysize)) - position;
+	const size_t ptrs = static_cast<size_t>(((reinterpret_cast<uintptr_t>(array) + static_cast<uintptr_t>(mysize)) - reinterpret_cast<uintptr_t>(position)));
 	   std::memmove(position + num, position, ptrs * sizeof(JSONNode *));
 	   std::memcpy(position, items, num * sizeof(JSONNode *));
 	   mysize += num;
@@ -281,7 +283,7 @@ JSON_PROTECTED
 #ifdef JSON_LESS_MEMORY
     class jsonChildren_Reserved : public jsonChildren {
     public:
-		LIBJSON_OBJECT(jsonChildren_Reserved);
+		LIBJSON_OBJECT(jsonChildren_Reserved)
 	   jsonChildren_Reserved(jsonChildren * orig, json_index_t siz) json_nothrow : jsonChildren(orig -> array, orig -> mysize, orig -> mycapacity), myreserved(siz) {
 		  orig -> array = 0;
 		  deleteChildren(orig);

--- a/_internal/Source/JSONDefs.h
+++ b/_internal/Source/JSONDefs.h
@@ -49,7 +49,7 @@
 #else
     #define json_throw(x) throw(x)
     #define json_try try
-    #define json_catch(exception, code) catch(exception){ code }
+    #define json_catch(exception, code) catch(const exception &){ code }
 #endif
 
 #ifdef JSON_STRICT

--- a/_internal/Source/JSONDefs/GNU_C.h
+++ b/_internal/Source/JSONDefs/GNU_C.h
@@ -3,13 +3,38 @@
 
 #ifdef __GNUC__
 
-    #define json_deprecated(method, warning) method __attribute__((deprecated))
+	#if !defined (json_deprecated)
+		#if defined (__cpp_attributes) && defined (__has_cpp_attribute)
+			#if __has_cpp_attribute(deprecated)
+				#define json_deprecated(method, warning) method [[deprecated(warning)]]
+			#endif
+		#endif
+		#if !defined (json_deprecated)
+			#define json_deprecated(method, warning) method __attribute__((deprecated))
+		#endif
+	#else
+		#define json_deprecated(method, warning) method
+	#endif
 
     #if (__GNUC__ >= 3)
 	   #define JSON_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
     #else
 	   #define JSON_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)
     #endif
+
+	#if !defined (json_fallthrough) && defined (__cpp_attributes) && defined (__has_cpp_attribute)
+	    #if __has_cpp_attribute(fallthrough)
+	        #define json_fallthrough [[fallthrough]]
+		#endif
+	#endif
+
+	#if !defined (json_fallthrough)
+		#if (JSON_GCC_VERSION >= 70000)
+			#define json_fallthrough __attribute__((fallthrough))
+		#else
+			#define json_fallthrough /* FALLTHRU */
+		#endif
+	#endif
 
     #if (JSON_GCC_VERSION >= 40300)
 	   #define json_hot __attribute__ ((hot))

--- a/_internal/Source/JSONDefs/Unknown_C.h
+++ b/_internal/Source/JSONDefs/Unknown_C.h
@@ -3,7 +3,25 @@
 
 #if !defined(__GNUC__) && !defined(_MSC_VER)
 
-    #define json_deprecated(method, warning) method
+    #if !defined (json_fallthrough) && defined (__cpp_attributes) && defined (__has_cpp_attribute)
+	    #if __has_cpp_attribute(fallthrough)
+	        #define json_fallthrough [[fallthrough]]
+		#endif
+	#endif
+
+    #if !defined (json_fallthrough)
+        #define json_fallthrough /* FALLTHRU */
+    #endif
+
+    #if !defined (json_deprecated)
+        #if defined (__cpp_attributes) && defined (__has_cpp_attribute)
+            #if __has_cpp_attribute(deprecated)
+                #define json_deprecated(method, warning) method [[deprecated(warning)]]
+            #endif
+        #endif
+    #else
+	    #define json_deprecated(method, warning) method
+    #endif
 
     #define json_nothrow
     #define json_throws(x)

--- a/_internal/Source/JSONDefs/Visual_C.h
+++ b/_internal/Source/JSONDefs/Visual_C.h
@@ -3,7 +3,29 @@
 
 #ifdef _MSC_VER
 
-    #define json_deprecated(method, warning) __declspec(deprecated(warning)) method
+    #if !defined (json_fallthrough) && defined (__cpp_attributes) && defined (__has_cpp_attribute)
+	    #if __has_cpp_attribute(fallthrough)
+	        #define json_fallthrough [[fallthrough]]
+		#endif
+	#endif
+
+    #if !defined (json_fallthrough)
+        #define json_fallthrough /* FALLTHRU */
+    #endif
+
+    #if !defined (json_deprecated)
+        #if defined (__cpp_attributes) && defined (__has_cpp_attribute)
+            #if __has_cpp_attribute(deprecated)
+                #define json_deprecated(method, warning) method [[deprecated(warning)]]
+            #endif
+        #endif
+        #if !defined (json_deprecated)
+            #define json_deprecated(method, warning) __declspec(deprecated(warning)) method
+        #endif
+    #else
+        #define json_deprecated(method, warning) method
+    #endif
+
 
     #define json_nothrow
     #define json_throws(x)

--- a/_internal/Source/JSONMemory.cpp
+++ b/_internal/Source/JSONMemory.cpp
@@ -34,11 +34,11 @@
 #ifdef JSON_MEMORY_POOL
 	#include "JSONMemoryPool.h"
     static bucket_pool_8<MEMPOOL_1, MEMPOOL_2, MEMPOOL_3, MEMPOOL_4, MEMPOOL_5, MEMPOOL_6, MEMPOOL_7, MEMPOOL_8> json_generic_mempool;
-    
+
 	//This class is only meant to initiate the mempool to start out using std::malloc/realloc/free
 	class mempool_callback_setter {
     public:
-		LIBJSON_OBJECT(mempool_callback_setter);
+		LIBJSON_OBJECT(mempool_callback_setter)
         inline mempool_callback_setter(void) json_nothrow {
 		`	LIBJSON_CTOR;
             mempool_callbacks::set(std::malloc, std::realloc, std::free);

--- a/_internal/Source/JSONMemory.h
+++ b/_internal/Source/JSONMemory.h
@@ -78,7 +78,7 @@
     class JSONNode;
     struct auto_expand {
     public:
-		LIBJSON_OBJECT(auto_expand);
+		LIBJSON_OBJECT(auto_expand)
 	   auto_expand(void) json_nothrow : mymap(){ LIBJSON_CTOR;}
 	   ~auto_expand(void) json_nothrow { purge(); LIBJSON_DTOR; }
 	   void purge(void) json_nothrow;
@@ -97,7 +97,7 @@
 
     struct auto_expand_node {
     public:
-		LIBJSON_OBJECT(auto_expand_node);
+		LIBJSON_OBJECT(auto_expand_node)
 	   auto_expand_node(void) json_nothrow : mymap(){ LIBJSON_CTOR; }
 	   ~auto_expand_node(void) json_nothrow { purge(); LIBJSON_DTOR; }
 	   void purge(void) json_nothrow ;
@@ -117,7 +117,7 @@
 	   class JSONStream;
 	   struct auto_expand_stream {
         public:
-			LIBJSON_OBJECT(auto_expand_stream);
+			LIBJSON_OBJECT(auto_expand_stream)
 		  auto_expand_stream(void) json_nothrow : mymap(){ LIBJSON_CTOR; }
 		  ~auto_expand_stream(void) json_nothrow { purge(); LIBJSON_DTOR; }
 		  void purge(void) json_nothrow ;
@@ -139,7 +139,7 @@
 template <typename T>
 class json_auto {
     public:
-		LIBJSON_OBJECT(json_auto);
+		LIBJSON_OBJECT(json_auto)
 	   json_auto(void) json_nothrow : ptr(0){ LIBJSON_CTOR; }
 	   json_auto(size_t count) json_nothrow : ptr(json_malloc<T>(count)){ LIBJSON_CTOR; }
 	   json_auto(T * arg) json_nothrow : ptr(arg){ LIBJSON_CTOR; }

--- a/_internal/Source/JSONNode.h
+++ b/_internal/Source/JSONNode.h
@@ -131,14 +131,14 @@
 
 class JSONNode {
 public:
-	LIBJSON_OBJECT(JSONNode);
+	LIBJSON_OBJECT(JSONNode)
     explicit JSONNode(char mytype = JSON_NODE) json_nothrow json_hot;
     #define DECLARE_CTOR(type) explicit JSONNode(const json_string & name_t, type value_t)
     DECLARE_FOR_ALL_TYPES(DECLARE_CTOR)
 
     JSONNode(const JSONNode & orig) json_nothrow json_hot;
     ~JSONNode(void) json_nothrow json_hot;
-    
+
     #if (defined(JSON_PREPARSE) && defined(JSON_READ_PRIORITY))
         static JSONNode stringType(const json_string & str);
         void set_name_(const json_string & newname) json_nothrow json_write_priority;
@@ -165,13 +165,13 @@ public:
     json_int_t as_int(void) const json_nothrow json_read_priority;
     json_number as_float(void) const json_nothrow json_read_priority;
     bool as_bool(void) const json_nothrow json_read_priority;
-    
+
     #ifdef JSON_CASTABLE
 	   JSONNode as_node(void) const json_nothrow json_read_priority;
 	   JSONNode as_array(void) const json_nothrow json_read_priority;
 	   void cast(char newtype) json_nothrow;
     #endif
-    
+
     #ifdef JSON_BINARY
 	   std::string as_binary(void) const json_nothrow json_cold;
 	   void set_binary(const unsigned char * bin, size_t bytes) json_nothrow json_cold;

--- a/_internal/Source/JSONNode_Mutex.cpp
+++ b/_internal/Source/JSONNode_Mutex.cpp
@@ -103,31 +103,31 @@ void JSONNode::lock(int thread) json_nothrow {
 
 void JSONNode::unlock(int thread) json_nothrow{
     JSON_ASSERT_SAFE(json_unlock_callback != 0, JSON_TEXT("No unlocking callback"), return;);
-	
+
     AutoLock lockControl;
-	
+
     //first, figure out what needs to be locked
     void * thislock = getThisLock(this);
 	#ifdef JSON_SAFE
 		if (thislock == 0) return;
 	#endif
-	
+
     //get it out of the map
     JSON_MAP(int, JSON_MAP(void *, unsigned int) )::iterator it = json_global(THREAD_LOCKS).find(thread);
     JSON_ASSERT_SAFE(it != json_global(THREAD_LOCKS).end(), JSON_TEXT("thread unlocking something it didn't lock"), return;);
-	
+
     //get the mutex out of the thread
     JSON_MAP(void *, unsigned int) & newthread = it -> second;
     JSON_MAP(void *, unsigned int)::iterator locker = newthread.find(thislock);
     JSON_ASSERT_SAFE(locker != newthread.end(), JSON_TEXT("thread unlocking mutex it didn't lock"), return;);
-	
+
     //unlock it
     if (--(locker -> second)) return;  //other nodes is this same thread still have a lock on it
-	
+
     //if I need to, unlock it
     newthread.erase(locker);
     json_unlock_callback(thislock);
-	
+
 }
 
 #ifdef JSON_MUTEX_MANAGE

--- a/_internal/Source/JSONPreparse.cpp
+++ b/_internal/Source/JSONPreparse.cpp
@@ -101,7 +101,7 @@ JSONNode JSONPreparse::isValidNumber(json_string::const_iterator & ptr, json_str
     json_string::const_iterator start = ptr;
     bool decimal = false;
     bool scientific = false;
-    
+
     //first letter is weird
     switch(*ptr){
 	   #ifndef JSON_STRICT
@@ -110,7 +110,7 @@ JSONNode JSONPreparse::isValidNumber(json_string::const_iterator & ptr, json_str
 		  break;
 	   case JSON_TEXT('+'):
 	   #endif
-		  
+
 	   case JSON_TEXT('-'):
 	   case JSON_TEXT('1'):
 	   case JSON_TEXT('2'):
@@ -151,7 +151,7 @@ JSONNode JSONPreparse::isValidNumber(json_string::const_iterator & ptr, json_str
 					   throw false;
 				}
 				break;
-				
+
 			 #ifndef JSON_STRICT
 			 case JSON_TEXT('x'):
 				while(isHex(*++ptr)){};
@@ -172,7 +172,7 @@ JSONNode JSONPreparse::isValidNumber(json_string::const_iterator & ptr, json_str
 				while((*++ptr >= JSON_TEXT('0')) && (*ptr <= JSON_TEXT('7'))){};
 				if ((*ptr != JSON_TEXT('8')) && (*ptr != JSON_TEXT('9'))){
 				    return JSONNode(json_global(EMPTY_JSON_STRING), FetchNumber(json_string(start, ptr - 1)));
-				} 
+				}
 				throw false;
 			 case JSON_TEXT('8'):
 			 case JSON_TEXT('9'):
@@ -219,7 +219,7 @@ JSONNode JSONPreparse::isValidNumber(json_string::const_iterator & ptr, json_str
 		  throw false;
     }
     ++ptr;
-    
+
     //next digits
     while (true){
 	   switch(*ptr){
@@ -294,7 +294,7 @@ JSONNode JSONPreparse::isValidMember(json_string::const_iterator & ptr, json_str
     //ptr is on the first character of the member
     //ptr will end up immediately after the last character in the member
     if (ptr == end) throw false;
-    
+
     switch(*ptr){
 	   case JSON_TEXT('\"'):{
            return JSONNode::stringType(isValidString(++ptr, end));
@@ -337,7 +337,7 @@ json_string JSONPreparse::isValidString(json_string::const_iterator & ptr, json_
     //ptr is pointing to the first character after the quote
     //ptr will end up behind the closing "
     json_string::const_iterator start = ptr;
-    
+
     while(ptr != end){
 	   switch(*ptr){
 		  case JSON_TEXT('\\'):
@@ -354,7 +354,7 @@ json_string JSONPreparse::isValidString(json_string::const_iterator & ptr, json_
 				case JSON_TEXT('u'):
 				    if (json_unlikely(!isHex(*++ptr))) throw false;
 				    if (json_unlikely(!isHex(*++ptr))) throw false;
-				    //fallthrough to \x
+				    json_fallthrough;
 				#ifndef JSON_STRICT
 				    case JSON_TEXT('x'):  //hex
 				#endif
@@ -488,7 +488,7 @@ JSONNode JSONPreparse::isValidRoot(const json_string & json) json_throws(std::in
 			   RETURN_NODE(isValidArray(++it, end), comment);
 	   }
     } catch (...){}
-    
+
     #ifndef JSON_NO_EXCEPTIONS
 	   throw std::invalid_argument(json_global(EMPTY_STD_STRING));
     #else

--- a/_internal/Source/JSONSharedString.h
+++ b/_internal/Source/JSONSharedString.h
@@ -39,7 +39,7 @@ public:
 	struct iterator;
 	  struct const_iterator {
 		const_iterator(const json_char * p, const json_shared_string * pa) : parent(pa), it(p){}
-	  
+
 		 inline const_iterator& operator ++(void) json_nothrow { ++it; return *this; }
 		 inline const_iterator& operator --(void) json_nothrow { --it; return *this; }
 		 inline const_iterator& operator +=(long i) json_nothrow { it += i; return *this; }
@@ -64,7 +64,7 @@ public:
 			result.it -= i;
 			return result;
 		 }
-		 inline const json_char & operator [](size_t pos) const json_nothrow { return it[pos]; };
+		 inline const json_char & operator [](size_t pos) const json_nothrow { return it[pos]; }
 		 inline const json_char & operator *(void) const json_nothrow { return *it; }
 		 inline const json_char * operator ->(void) const json_nothrow { return it; }
 		 inline bool operator == (const const_iterator & other) const json_nothrow { return it == other.it; }
@@ -89,10 +89,10 @@ public:
 		 friend class json_shared_string;
 		 friend struct iterator;
 	  };
-	  
+
 	  struct iterator {
 		iterator(const json_char * p, const json_shared_string * pa) : parent(pa), it(p){}
-	  
+
 		 inline iterator& operator ++(void) json_nothrow { ++it; return *this; }
 		 inline iterator& operator --(void) json_nothrow { --it; return *this; }
 		 inline iterator& operator +=(long i) json_nothrow { it += i; return *this; }
@@ -117,7 +117,7 @@ public:
 			result.it -= i;
 			return result;
 		 }
-		 inline const json_char & operator [](size_t pos) const json_nothrow { return it[pos]; };
+		 inline const json_char & operator [](size_t pos) const json_nothrow { return it[pos]; }
 		 inline const json_char & operator *(void) const json_nothrow { return *it; }
 		 inline const json_char * operator ->(void) const json_nothrow { return it; }
 		 inline bool operator == (const const_iterator & other) const json_nothrow { return it == other.it; }
@@ -146,68 +146,68 @@ public:
 
 
 	inline json_shared_string::iterator begin(void){
-		iterator res = iterator(data(), this); 
+		iterator res = iterator(data(), this);
 		return res;
 	}
 	inline json_shared_string::iterator end(void){
-		iterator res = iterator(data() + len, this); 
+		iterator res = iterator(data() + len, this);
 		return res;
 	}
 	inline json_shared_string::const_iterator begin(void) const {
-		const_iterator res = const_iterator(data(), this); 
+		const_iterator res = const_iterator(data(), this);
 		return res;
 	}
 	inline json_shared_string::const_iterator end(void) const {
-		const_iterator res = const_iterator(data() + len, this); 
+		const_iterator res = const_iterator(data() + len, this);
 		return res;
 	}
-	
+
 
 	inline json_string::iterator std_begin(void){
-		return _str -> mystring.begin() + offset;
+		return _str -> mystring.begin() + static_cast<json_string::difference_type>(offset);
 	}
 	inline json_string::iterator std_end(void){
-		return std_begin() + len;
+		return std_begin() + static_cast<json_string::difference_type>(len);
 	}
-	
+
 	inline json_string::const_iterator std_begin(void) const{
-		return _str -> mystring.begin() + offset;
+		return _str -> mystring.begin() + static_cast<json_string::difference_type>(offset);
 	}
 	inline json_string::const_iterator std_end(void) const{
-		return std_begin() + len;
+		return std_begin() + static_cast<json_string::difference_type>(len);
 	}
-	
-	inline json_shared_string(void) : offset(0), len(0), _str(new(json_malloc<json_shared_string_internal>(1)) json_shared_string_internal(json_global(EMPTY_JSON_STRING))) {}
-	
-	inline json_shared_string(const json_string & str) : offset(0), len(str.length()), _str(new(json_malloc<json_shared_string_internal>(1)) json_shared_string_internal(str)) {}
-	
+
+	inline json_shared_string(void) : _str(new(json_malloc<json_shared_string_internal>(1)) json_shared_string_internal(json_global(EMPTY_JSON_STRING))), offset(0), len(0) {}
+
+	inline json_shared_string(const json_string & str) : _str(new(json_malloc<json_shared_string_internal>(1)) json_shared_string_internal(str)), offset(0), len(str.length()) {}
+
 	inline json_shared_string(const json_shared_string & str, size_t _offset, size_t _len) : _str(str._str), offset(str.offset + _offset), len(_len) {
 		++_str -> refCount;
 	}
-	
+
 	inline json_shared_string(const json_shared_string & str, size_t _offset) : _str(str._str), offset(str.offset + _offset), len(str.len - _offset) {
 		++_str -> refCount;
 	}
-	
-	inline json_shared_string(const iterator & s, const iterator & e) : _str(s.parent -> _str), offset(s.it - s.parent -> _str -> mystring.data()), len(e.it - s.it){
+
+	inline json_shared_string(const iterator & s, const iterator & e) : _str(s.parent -> _str), offset(static_cast<size_t>(s.it - s.parent -> _str -> mystring.data())), len(static_cast<size_t>(e.it - s.it)){
 		++_str -> refCount;
 	}
-	
+
 	inline ~json_shared_string(void){
 		deref();
 	}
-	
+
 	inline bool empty(void) const { return len == 0; }
-	
+
 	size_t find(json_char ch, size_t pos = 0) const {
 		if (_str -> refCount == 1) return _str -> mystring.find(ch, pos);
 		json_string::const_iterator e = std_end();
-		for(json_string::const_iterator b = std_begin() + pos; b != e; ++b){
-			if (*b == ch) return b - std_begin();
+		for(json_string::const_iterator b = std_begin() + static_cast<json_string::difference_type>(pos); b != e; ++b){
+			if (*b == ch) return static_cast<size_t>(b - std_begin());
 		}
 		return json_string::npos;
 	}
-	
+
 	inline json_char & operator[] (size_t loc){
 		return _str -> mystring[loc + offset];
 	}
@@ -218,21 +218,21 @@ public:
 	inline size_t length() const { return len; }
 	inline const json_char * c_str() const { return toString().c_str(); }
 	inline const json_char * data() const { return _str -> mystring.data() + offset; }
-	
+
 	inline bool operator != (const json_shared_string & other) const {
 		if ((other._str == _str) && (other.len == len) && (other.offset == offset)) return false;
 		return other.toString() != toString();
 	}
-	
+
 	inline bool operator == (const json_shared_string & other) const {
 		if ((other._str == _str) && (other.len == len) && (other.offset == offset)) return true;
 		return other.toString() == toString();
 	}
-	
+
 	inline bool operator == (const json_string & other) const {
 		return other == toString();
 	}
-	
+
 	json_string & toString(void) const {
 		//gonna have to do a real substring now anyway, so do it completely
 		if (_str -> refCount == 1){
@@ -246,8 +246,8 @@ public:
 		offset = 0;
 		return _str -> mystring;
 	}
-	
-	
+
+
 	inline void assign(const json_shared_string & other, size_t _offset, size_t _len){
 		if (other._str != _str){
 			deref();
@@ -257,11 +257,11 @@ public:
 		offset = other.offset + _offset;
 		len = _len;
 	}
-	
+
 	json_shared_string(const json_shared_string & other) : _str(other._str), offset(other.offset), len(other.len){
 		++_str -> refCount;
 	}
-	
+
 	json_shared_string & operator =(const json_shared_string & other){
 		if (other._str != _str){
 			deref();
@@ -272,13 +272,13 @@ public:
 		len = other.len;
 		return *this;
 	}
-	
+
 	json_shared_string & operator += (const json_char c){
 		toString() += c;
 		++len;
 		return *this;
 	}
-	
+
 	//when doing a plus equal of another string, see if it shares the string and starts where this one left off, in which case just increase len
 JSON_PRIVATE
 	struct json_shared_string_internal {

--- a/_internal/Source/JSONStats.h
+++ b/_internal/Source/JSONStats.h
@@ -8,35 +8,39 @@
 		static size_t & getCtorCounter(void){\
 			static size_t count = 0;\
 			static int i = JSONStats::setCallbacks(getCtorCounter, getCopyCtorCounter, getAssignmentCounter, getDtorCounter, #name);\
+			static_cast<void>(i);\
 			return count;\
 		}\
 		static size_t & getCopyCtorCounter(void){\
 			static size_t count = 0;\
 			static int i = JSONStats::setCallbacks(getCtorCounter, getCopyCtorCounter, getAssignmentCounter, getDtorCounter, #name);\
+			static_cast<void>(i);\
 			return count;\
 		}\
 		static size_t & getAssignmentCounter(void){\
 			static size_t count = 0;\
 			static int i = JSONStats::setCallbacks(getCtorCounter, getCopyCtorCounter, getAssignmentCounter, getDtorCounter, #name);\
+			static_cast<void>(i);\
 			return count;\
 		}\
 		static size_t & getDtorCounter(void){\
 			static size_t count = 0;\
 			static int i = JSONStats::setCallbacks(getCtorCounter, getCopyCtorCounter, getAssignmentCounter, getDtorCounter, #name);\
+			static_cast<void>(i);\
 			return count;\
 		}
 	#define LIBJSON_CTOR getCtorCounter() += 1
 	#define LIBJSON_COPY_CTOR getCopyCtorCounter() += 1
 	#define LIBJSON_ASSIGNMENT getAssignmentCounter() += 1
 	#define LIBJSON_DTOR getDtorCounter() += 1
-	
+
 	#include <map>
 	#include <sstream>
 	#include <iostream>
 	#include <string>
 	class JSONStats {
 	public:
-		~JSONStats(void){ 
+		~JSONStats(void){
 			std::map<getCounter_m, objectStructure*> & mymap = getMapper();
 			std::map<getCounter_m, objectStructure*>::iterator b = mymap.begin();
 			std::map<getCounter_m, objectStructure*>::iterator e = mymap.end();
@@ -50,22 +54,22 @@
 				delete b -> second;
 			}
 		}
-		
+
 		typedef size_t & (*getCounter_m)(void);
 		struct objectStructure {
 			objectStructure(getCounter_m cTor, getCounter_m ccTor, getCounter_m assign, getCounter_m dTor, const std::string & name):
 				_cTor(cTor), _ccTor(ccTor), _assign(assign), _dTor(dTor), _name(name){}
-			std::string _name;
 			getCounter_m _cTor;
 			getCounter_m _ccTor;
 			getCounter_m _assign;
 			getCounter_m _dTor;
+			std::string _name;
 		};
 		static int setCallbacks(getCounter_m cTor, getCounter_m ccTor, getCounter_m assign, getCounter_m dtor, const std::string & name){
 			getMapper()[cTor] = new objectStructure (cTor, ccTor, assign, dtor, name);
 			return 0;
 		}
-		
+
 		static std::map<getCounter_m, objectStructure*> & getMapper(void) {
 			static std::map<getCounter_m, objectStructure*> mymap;
 			return mymap;

--- a/_internal/Source/JSONStream.cpp
+++ b/_internal/Source/JSONStream.cpp
@@ -5,11 +5,11 @@
 #include "JSONValidator.h"
 
 
-JSONStream::JSONStream(json_stream_callback_t call_p, json_stream_e_callback_t call_e, void * callbackIdentifier) json_nothrow : state(true), call(call_p), err_call(call_e), buffer(), callback_identifier(callbackIdentifier) {
+JSONStream::JSONStream(json_stream_callback_t call_p, json_stream_e_callback_t call_e, void * callbackIdentifier) json_nothrow : buffer(), call(call_p), err_call(call_e), callback_identifier(callbackIdentifier), state(true) {
 	LIBJSON_CTOR;
 }
 
-JSONStream::JSONStream(const JSONStream & orig) json_nothrow : state(orig.state), call(orig.call), err_call(orig.err_call), buffer(orig.buffer), callback_identifier(orig.callback_identifier){
+JSONStream::JSONStream(const JSONStream & orig) json_nothrow : buffer(orig.buffer), call(orig.call), err_call(orig.err_call), callback_identifier(orig.callback_identifier), state(orig.state){
 	LIBJSON_COPY_CTOR;
 }
 
@@ -76,9 +76,9 @@ JSONStream & JSONStream::operator =(const JSONStream & orig) json_nothrow {
 	#define STREAM_FIND_NEXT_RELEVANT(ch, vt, po) FindNextRelevant(ch, vt, po)
 	size_t JSONStream::FindNextRelevant(json_char ch, const json_string & value_t, const size_t pos) json_nothrow {
 #endif
-    const json_char * start = value_t.c_str();
-    for (const json_char * p = start + pos; *p; ++p){
-	   if (json_unlikely(*p == ch)) return p - start;
+	 const json_char * start = value_t.c_str();
+	 for (const json_char * p = start + pos; *p; ++p){
+		 if (json_unlikely(*p == ch)) return static_cast<size_t>(reinterpret_cast<uintptr_t>(p) - reinterpret_cast<uintptr_t>(start));
 	   switch (*p){
 			 BRACKET_STREAM(JSON_TEXT('['), JSON_TEXT(']'))
 			 BRACKET_STREAM(JSON_TEXT('{'), JSON_TEXT('}'))
@@ -114,21 +114,21 @@ void JSONStream::parse(void) json_nothrow {
 				 #endif
 			  END_MEM_SCOPE
 			  json_string::iterator beginning = buffer.begin();
-			  buffer.erase(beginning, beginning + end);
+			  buffer.erase(beginning, beginning + static_cast<json_string::difference_type>(end));
 			  continue; //parse();  //parse the next object too
 		   }
 		   #ifdef JSON_SAFE
 				else {
 					//verify that what's in there is at least valid so far
 					#ifndef JSON_VALIDATE
-						#error In order to use safe mode and streams, JSON_VALIDATE needs to be defined			
+						#error In order to use safe mode and streams, JSON_VALIDATE needs to be defined
 					#endif
-					
+
 					json_auto<json_char> s;
 					size_t len;
 					s.set(JSONWorker::RemoveWhiteSpace(json_string(buffer.c_str() + pos), len, false));
-					
-					
+
+
 					if (!JSONValidator::isValidPartialRoot(s.ptr)){
 						if (err_call) err_call(getIdentifier());
 						state = false;

--- a/_internal/Source/JSONStream.h
+++ b/_internal/Source/JSONStream.h
@@ -24,7 +24,7 @@ typedef void (*json_stream_callback_t)(JSONNode &, void *);
 
 class JSONStream {
 public:
-	LIBJSON_OBJECT(JSONStream);
+	LIBJSON_OBJECT(JSONStream)
     JSONStream(json_stream_callback_t call_p, json_stream_e_callback_t call_e = NULL, void * callbackIdentifier = JSONSTREAM_SELF) json_nothrow;
     JSONStream(const JSONStream & orig) json_nothrow;
     JSONStream & operator =(const JSONStream & orig) json_nothrow;
@@ -34,7 +34,7 @@ public:
 #else
 	JSONStream & operator << (const json_string & str) json_nothrow;
 #endif
-	
+
     static void deleteJSONStream(JSONStream * stream) json_nothrow {
 #ifdef JSON_MEMORY_CALLBACKS
 		stream -> ~JSONStream();
@@ -43,7 +43,7 @@ public:
 		delete stream;
 #endif
     }
-	
+
     static JSONStream * newJSONStream(json_stream_callback_t callback, json_stream_e_callback_t call_e, void * callbackIdentifier) json_nothrow {
 #ifdef JSON_MEMORY_CALLBACKS
 		return new(json_malloc<JSONStream>(1)) JSONStream(callback, call_e, callbackIdentifier);
@@ -51,7 +51,7 @@ public:
 		return new JSONStream(callback, call_e, callbackIdentifier);
 #endif
     }
-	
+
 	inline void reset() json_nothrow {
 		state = true;
 		buffer.clear();
@@ -63,14 +63,14 @@ JSON_PRIVATE
 		}
 		return callback_identifier;
 	}
-	
+
 	#if (JSON_READ_PRIORITY == HIGH) && (!(defined(JSON_LESS_MEMORY)))
 		template<json_char ch>
 		static size_t FindNextRelevant(const json_string & value_t, const size_t pos) json_nothrow json_read_priority;
 	#else
 		static size_t FindNextRelevant(json_char ch, const json_string & value_t, const size_t pos) json_nothrow json_read_priority;
 	#endif
-	
+
     void parse(void) json_nothrow;
     json_string buffer;
     json_stream_callback_t call;

--- a/_internal/Source/JSONValidator.cpp
+++ b/_internal/Source/JSONValidator.cpp
@@ -270,14 +270,26 @@ bool JSONValidator::isValidString(const json_char * & ptr) json_nothrow {
 				case JSON_TEXT('t'):
 				    break;
 				case JSON_TEXT('u'):
-				    if (json_unlikely(!isHex(*++ptr))) return false;
-				    if (json_unlikely(!isHex(*++ptr))) return false;
-				    //fallthrough to \x
+				    if (json_unlikely(!isHex(*++ptr)))
+					{
+						return false;
+					}
+				    if (json_unlikely(!isHex(*++ptr)))
+					{
+						return false;
+					}
+				    json_fallthrough;
 				#ifndef JSON_STRICT
 				case JSON_TEXT('x'):  //hex
 				#endif
-				    if (json_unlikely(!isHex(*++ptr))) return false;
-				    if (json_unlikely(!isHex(*++ptr))) return false;
+				    if (json_unlikely(!isHex(*++ptr)))
+					{
+						return false;
+					}
+				    if (json_unlikely(!isHex(*++ptr)))
+					{
+						return false;
+					}
 				    break;
 				#ifdef JSON_OCTAL
 				    #ifdef __GNUC__
@@ -292,8 +304,14 @@ bool JSONValidator::isValidString(const json_char * & ptr) json_nothrow {
 				    case JSON_TEXT('6'):
 				    case JSON_TEXT('7'):
 				    #endif
-					   if (json_unlikely((*++ptr < JSON_TEXT('0')) || (*ptr > JSON_TEXT('7')))) return false;
-					   if (json_unlikely((*++ptr < JSON_TEXT('0')) || (*ptr > JSON_TEXT('7')))) return false;
+					   if (json_unlikely((*++ptr < JSON_TEXT('0')) || (*ptr > JSON_TEXT('7'))))
+					   {
+						return false;
+					   }
+					   if (json_unlikely((*++ptr < JSON_TEXT('0')) || (*ptr > JSON_TEXT('7'))))
+					   {
+							return false;
+					   }
 					   break;
 				#endif
 				default:

--- a/_internal/Source/JSONWorker.cpp
+++ b/_internal/Source/JSONWorker.cpp
@@ -6,7 +6,7 @@
 #if !defined (INTPTR_MAX) && !defined (__intptr_t_defined)
 //If this is not defined, then assume intptr_t is not available.
 //manually defined here if this is the case (unlikely at this point)
-//using long long as that will be more than big enough in both 32bit and 64bit. 
+//using long long as that will be more than big enough in both 32bit and 64bit.
 //If you want to add more ifdef's here to change this definition, go for it, but it is only necessary if intptr_t is not already available.
 typedef long long intptr_t;
 #endif
@@ -38,10 +38,10 @@ JSONNode JSONWorker::parse_unformatted(const json_string & json) /*json_throws(s
 }
 
 JSONNode JSONWorker::_parse_unformatted(const json_char * json, const json_char * const end) /*json_throws(std::invalid_argument)*/ {
-    #ifdef JSON_COMMENTS
-	   json_char firstchar = *json;
-	   json_string _comment;
-	   json_char * runner = (json_char*)json;
+	 #ifdef JSON_COMMENTS
+		 json_char firstchar = *json;
+		 json_string _comment;
+		 json_char * runner = const_cast<json_char*>(json);
 	   if (json_unlikely(firstchar == JSON_TEMP_COMMENT_IDENTIFIER)){  //multiple comments will be consolidated into one
 		  newcomment:
 		  while(*(++runner) != JSON_TEMP_COMMENT_IDENTIFIER){
@@ -74,12 +74,12 @@ JSONNode JSONWorker::_parse_unformatted(const json_char * json, const json_char 
 				}
 			 }
 		  #endif
-		  #ifdef JSON_COMMENTS
-			 JSONNode foo(json_string(runner, end - runner));
-			 foo.set_comment(_comment);
+		#ifdef JSON_COMMENTS
+					 JSONNode foo(json_string(runner, static_cast<json_string::size_type>(end - runner)));
+					 foo.set_comment(_comment);
 			 return JSONNode(true, foo);  //forces it to simply return the original interal, even with ref counting off
 		  #else
-			 return JSONNode(json_string(json, end - json));
+			 return JSONNode(json_string(json, static_cast<json_string::size_type>(end - json)));
 		  #endif
     }
 
@@ -140,8 +140,8 @@ JSONNode JSONWorker::_parse_unformatted(const json_char * json, const json_char 
 	#endif
 		json_string::const_iterator start = value_t.begin();
 		json_string::const_iterator e = value_t.end();
-	   for (json_string::const_iterator p = value_t.begin() + pos; p != e; ++p){
-		  if (json_unlikely(*p == ch)) return p - start;
+		 for (json_string::const_iterator p = value_t.begin() + static_cast<json_string::difference_type>(pos); p != e; ++p){
+			 if (json_unlikely(*p == ch)) return static_cast<size_t>(p - start);
 		  switch (*p){
 				BRACKET(JSON_TEXT('['), JSON_TEXT(']'))
 				BRACKET(JSON_TEXT('{'), JSON_TEXT('}'))
@@ -199,7 +199,7 @@ inline void SingleLineComment(const json_char * & p, const json_char * const end
 				   if (T) COMMENT_DELIMITER();
 				   while ((*(++p) != JSON_TEXT('*')) || (*(p + 1) != JSON_TEXT('/'))){
 					  if(p == end){
-							COMMENT_DELIMITER(); 
+							COMMENT_DELIMITER();
 							goto endofrunner;
 						}
 					  if (T) *runner++ = *p;
@@ -210,6 +210,7 @@ inline void SingleLineComment(const json_char * & p, const json_char * const end
 				}
 				//Should be a single line C comment, so let it fall through to use the bash comment stripper
 				JSON_ASSERT_SAFE(*p == JSON_TEXT('/'), JSON_TEXT("stray / character, not quoted, or a comment"), goto endofrunner;);
+				json_fallthrough;
 			case JSON_TEXT('#'):  //a bash comment
 				if (T){
 					SingleLineComment(p, end AND_RUNNER);
@@ -237,6 +238,7 @@ inline void SingleLineComment(const json_char * & p, const json_char * const end
 				}
 			}
 			//no break, let it fall through so that the trailing quote gets added
+			json_fallthrough;
 		 default:
 			JSON_ASSERT_SAFE((json_uchar)*p >= 32, JSON_TEXT("Invalid JSON character detected (lo)"), goto endofrunner;);
 			JSON_ASSERT_SAFE((json_uchar)*p <= 126, JSON_TEXT("Invalid JSON character detected (hi)"), goto endofrunner;);
@@ -245,13 +247,13 @@ inline void SingleLineComment(const json_char * & p, const json_char * const end
 	  }
 	}
 	endofrunner:
-	len = runner - result;
+	len = static_cast<size_t>(reinterpret_cast<uintptr_t>(runner) - reinterpret_cast<uintptr_t>(result));
 	return result;
 }
 
 #ifdef JSON_READ_PRIORITY
     json_char * JSONWorker::RemoveWhiteSpace(const json_string & value_t, size_t & len, bool escapeQuotes) json_nothrow  {
-		json_char * result = PRIVATE_REMOVEWHITESPACE(true, value_t, escapeQuotes, len); 
+		json_char * result = PRIVATE_REMOVEWHITESPACE(true, value_t, escapeQuotes, len);
 		result[len] = JSON_TEXT('\0');
 		return result;
     }
@@ -267,7 +269,7 @@ json_char * JSONWorker::RemoveWhiteSpaceAndCommentsC(const json_string & value_t
 json_string JSONWorker::RemoveWhiteSpaceAndComments(const json_string & value_t, bool escapeQuotes) json_nothrow {
 	json_auto<json_char> s;
     size_t len;
-	s.set(PRIVATE_REMOVEWHITESPACE(false, value_t, escapeQuotes, len)); 
+	s.set(PRIVATE_REMOVEWHITESPACE(false, value_t, escapeQuotes, len));
 	return json_string(s.ptr, len);
 }
 
@@ -306,16 +308,16 @@ json_string JSONWorker::RemoveWhiteSpaceAndComments(const json_string & value_t,
 
 json_uchar JSONWorker::UTF8(const json_char * & pos, const json_char * const end) json_nothrow {
 	JSON_ASSERT_SAFE(((intptr_t)end - (intptr_t)pos) > 4, JSON_TEXT("UTF will go out of bounds"), return JSON_TEXT('\0'););
-    #ifdef JSON_UNICODE
-	   ++pos;
-	   json_uchar temp = Hex(pos) << 8;
-	   ++pos;
-	   return temp | Hex(pos);
+	#ifdef JSON_UNICODE
+		++pos;
+		json_uchar temp = static_cast<json_uchar>(Hex(pos)) << 8;
+		++pos;
+		return temp | static_cast<json_uchar>(Hex(pos));
     #else
 	   JSON_ASSERT(*(pos + 1) == JSON_TEXT('0'), JSON_TEXT("wide utf character (hihi)"));
 	   JSON_ASSERT(*(pos + 2) == JSON_TEXT('0'), JSON_TEXT("wide utf character (hilo)"));
-	   pos += 3;
-	   return Hex(pos);
+	pos += 3;
+	return static_cast<json_uchar>(Hex(pos));
     #endif
 }
 
@@ -391,9 +393,9 @@ void JSONWorker::SpecialChar(const json_char * & pos, const json_char * const en
 	   case JSON_TEXT('u'):	//utf character
 		  #ifdef JSON_UNICODE
 			 UTF(pos, res, end);
-		  #else
-			 res += UTF8(pos, end);
-		  #endif
+			 #else
+				 res += static_cast<json_char>(UTF8(pos, end));
+			 #endif
 		  break;
 	   #ifndef JSON_STRICT
 		  case JSON_TEXT('x'):   //hexidecimal ascii code
@@ -509,8 +511,8 @@ void JSONWorker::SpecialChar(const json_char * & pos, const json_char * const en
 	   if (hi > 57) hi += 7; //A-F don't immediately follow 0-9, so have to further adjust those
 	   json_uchar lo = (p & 0x000F) + 48;
 	   if (lo > 57) lo += 7; //A-F don't immediately follow 0-9, so have to further adjust those
-	   res += hi;
-	   res += lo;
+	res += static_cast<json_char>(hi);
+	res += static_cast<json_char>(lo);
 	   return res;
     }
 #endif
@@ -627,60 +629,60 @@ void JSONWorker::DoArray(const internalJSONNode * parent, const json_string & va
 	JSON_ASSERT(!value_t.empty(), JSON_TEXT("DoArray is empty"));
 	JSON_ASSERT_SAFE(value_t[0] == JSON_TEXT('['), JSON_TEXT("DoArray is not an array"), parent -> Nullify(); return;);
 	if (json_unlikely(value_t.length() <= 2)) return;  // just a [] (blank array)
-	
+
 	#ifdef JSON_SAFE
 		json_string newValue;  //share this so it has a reserved buffer
 	#endif
 	size_t starting = 1;  //ignore the [
-	
+
 	//Not sure what's in the array, so we have to use commas
 	for(size_t ending = FIND_NEXT_RELEVANT(JSON_TEXT(','), value_t, 1);
 		ending != json_string::npos;
 		ending = FIND_NEXT_RELEVANT(JSON_TEXT(','), value_t, starting)){
-		
+
 		#ifdef JSON_SAFE
-			newValue.assign(value_t.begin() + starting, value_t.begin() + ending);
+			newValue.assign(value_t.begin() + static_cast<json_string::difference_type>(starting), value_t.begin() + static_cast<json_string::difference_type>(ending));
 			JSON_ASSERT_SAFE(FIND_NEXT_RELEVANT(JSON_TEXT(':'), newValue, 0) == json_string::npos, JSON_TEXT("Key/Value pairs are not allowed in arrays"), parent -> Nullify(); return;);
 			NewNode(parent, json_global(EMPTY_JSON_STRING), newValue, true);
 		#else
-			NewNode(parent, json_global(EMPTY_JSON_STRING), json_string(value_t.begin() + starting, value_t.begin() + ending), true);
+			NewNode(parent, json_global(EMPTY_JSON_STRING), json_string(value_t.begin() + static_cast<json_string::difference_type>(starting), value_t.begin() + static_cast<json_string::difference_type>(ending)), true);
 		#endif
 		starting = ending + 1;
 	}
 	//since the last one will not find the comma, we have to add it here, but ignore the final ]
-	
+
 	#ifdef JSON_SAFE
-		newValue.assign(value_t.begin() + starting, value_t.end() - 1);
+		newValue.assign(value_t.begin() + static_cast<json_string::difference_type>(starting), value_t.end() - 1);
 		JSON_ASSERT_SAFE(FIND_NEXT_RELEVANT(JSON_TEXT(':'), newValue, 0) == json_string::npos, JSON_TEXT("Key/Value pairs are not allowed in arrays"), parent -> Nullify(); return;);
 		NewNode(parent, json_global(EMPTY_JSON_STRING), newValue, true);
 	#else
-		NewNode(parent, json_global(EMPTY_JSON_STRING), json_string(value_t.begin() + starting, value_t.end() - 1), true);
+		NewNode(parent, json_global(EMPTY_JSON_STRING), json_string(value_t.begin() + static_cast<json_string::difference_type>(starting), value_t.end() - 1), true);
 	#endif
 }
 
 
 //Create all child nodes
-void JSONWorker::DoNode(const internalJSONNode * parent, const json_string & value_t) json_nothrow {	
+void JSONWorker::DoNode(const internalJSONNode * parent, const json_string & value_t) json_nothrow {
 	//This take a node and creates its members and such
 	JSON_ASSERT(!value_t.empty(), JSON_TEXT("DoNode is empty"));
 	JSON_ASSERT_SAFE(value_t[0] == JSON_TEXT('{'), JSON_TEXT("DoNode is not an node"), parent -> Nullify(); return;);
 	if (json_unlikely(value_t.length() <= 2)) return;  // just a {} (blank node)
-	
+
 	size_t name_ending = FIND_NEXT_RELEVANT(JSON_TEXT(':'), value_t, 1);  //find where the name ends
 	JSON_ASSERT_SAFE(name_ending != json_string::npos, JSON_TEXT("Missing :"), parent -> Nullify(); return;);
-	json_string name(value_t.begin() + 1, value_t.begin() + name_ending - 1);	  //pull the name out
+		json_string name(value_t.begin() + 1, value_t.begin() + static_cast<json_string::difference_type>(name_ending - 1));	  //pull the name out
 	for (size_t value_ending = FIND_NEXT_RELEVANT(JSON_TEXT(','), value_t, name_ending),  //find the end of the value
 		 name_starting = 1;  //ignore the {
 		 value_ending != json_string::npos;
 		 value_ending = FIND_NEXT_RELEVANT(JSON_TEXT(','), value_t, name_ending)){
-		
-		NewNode(parent, name, json_string(value_t.begin() + name_ending + 1, value_t.begin() + value_ending), false);
+
+		NewNode(parent, name, json_string(value_t.begin() + static_cast<json_string::difference_type>(name_ending + 1), value_t.begin() + static_cast<json_string::difference_type>(value_ending)), false);
 		name_starting = value_ending + 1;
 		name_ending = FIND_NEXT_RELEVANT(JSON_TEXT(':'), value_t, name_starting);
 		JSON_ASSERT_SAFE(name_ending != json_string::npos, JSON_TEXT("Missing :"), parent -> Nullify(); return;);
-		name.assign(value_t.begin() + name_starting, value_t.begin() + name_ending - 1);
+		name.assign(value_t.begin() + static_cast<json_string::difference_type>(name_starting), value_t.begin() + static_cast<json_string::difference_type>(name_ending - 1));
 	}
 	//since the last one will not find the comma, we have to add it here
-	NewNode(parent, name, json_string(value_t.begin() + name_ending + 1, value_t.end() - 1), false);
+	NewNode(parent, name, json_string(value_t.begin() + static_cast<json_string::difference_type>(name_ending + 1), value_t.end() - 1), false);
 }
 #endif

--- a/_internal/Source/JSONWriter.cpp
+++ b/_internal/Source/JSONWriter.cpp
@@ -128,9 +128,9 @@ void internalJSONNode::WriteChildren(unsigned int indent, json_string & output) 
 	   if (indent == 0xFFFFFFFF) return;
 	   if (json_likely(_comment.empty())) return;
 	   size_t pos = _comment.find(JSON_TEXT('\n'));
-		
+
 	   const json_string current_indent(json_global(NEW_LINE) + makeIndent(indent));
-		
+
 	   if (json_likely(pos == json_string::npos)){  //Single line comment
 		   output += current_indent;
 		   output += json_global(SINGLELINE_COMMENT);
@@ -154,8 +154,8 @@ void internalJSONNode::WriteChildren(unsigned int indent, json_string & output) 
 		  #if defined(JSON_WRITE_BASH_COMMENTS) || defined(JSON_WRITE_SINGLE_LINE_COMMENTS)
 			 output += json_global(SINGLELINE_COMMENT);
 		  #endif
-		  output.append(_comment.begin() + old, _comment.begin() + pos);
-		  
+		  output.append(_comment.begin() + static_cast<json_string::difference_type>(old), _comment.begin() + static_cast<json_string::difference_type>(pos));
+
 		  #if defined(JSON_WRITE_BASH_COMMENTS) || defined(JSON_WRITE_SINGLE_LINE_COMMENTS)
 			 output += current_indent;
 		  #else
@@ -167,7 +167,7 @@ void internalJSONNode::WriteChildren(unsigned int indent, json_string & output) 
 	   #if defined(JSON_WRITE_BASH_COMMENTS) || defined(JSON_WRITE_SINGLE_LINE_COMMENTS)
 		  output += json_global(SINGLELINE_COMMENT);
 	   #endif
-	   output.append(_comment.begin() + old, _comment.end());
+	   output.append(_comment.begin() + static_cast<json_string::difference_type>(old), _comment.end());
 	   output += current_indent;
 	   #if !(defined(JSON_WRITE_BASH_COMMENTS) || defined(JSON_WRITE_SINGLE_LINE_COMMENTS))
 		  output += JSON_TEXT("*/");
@@ -195,7 +195,7 @@ void internalJSONNode::DumpRawString(json_string & output) const json_nothrow {
 void internalJSONNode::Write(unsigned int indent, bool arrayChild, json_string & output) const json_nothrow {
     const bool formatted = indent != 0xFFFFFFFF;
 	WriteComment(indent, output);
-	
+
     #if !defined(JSON_PREPARSE) && defined(JSON_READ_PRIORITY)
 	   if (!(formatted || fetched)){  //It's not formatted or fetched, just do a raw dump
 		   WriteName(false, arrayChild, output);
@@ -242,7 +242,7 @@ void internalJSONNode::Write(unsigned int indent, bool arrayChild, json_string &
 	#endif
 			output += JSON_TEXT("\"");
 			JSONWorker::UnfixString(_string, _string_encoded, output);  //It's already been fetched, meaning that it's unescaped
-			output += JSON_TEXT("\"");  
+			output += JSON_TEXT("\"");
 	#if !defined(JSON_PREPARSE) && defined(JSON_READ_PRIORITY)
 		} else {
 			DumpRawString(output);  //it hasn't yet been fetched, so it's already unescaped, just do a dump

--- a/_internal/Source/internalJSONNode.cpp
+++ b/_internal/Source/internalJSONNode.cpp
@@ -5,8 +5,8 @@
 #include "JSONGlobals.h"
 
 internalJSONNode::internalJSONNode(const internalJSONNode & orig) json_nothrow :
-    _type(orig._type), _name(orig._name), _name_encoded(orig._name_encoded),
-    _string(orig._string), _string_encoded(orig._string_encoded), _value(orig._value)
+	_type(orig._type), _numtype(orig._numtype), _name(orig._name), _name_encoded(orig._name_encoded),
+	_string(orig._string), _string_encoded(orig._string_encoded), _value(orig._value)
     initializeMutex(0)
     initializeRefCount(1)
     initializeFetch(orig.fetched)
@@ -37,7 +37,7 @@ internalJSONNode::internalJSONNode(const internalJSONNode & orig) json_nothrow :
 
 //this one is specialized because the root can only be array or node
 #ifdef JSON_READ_PRIORITY /*-> JSON_READ_PRIORITY */
-internalJSONNode::internalJSONNode(const json_string & unparsed) json_nothrow : _type(), _name(),_name_encoded(false), _string(unparsed), _string_encoded(), _value()
+internalJSONNode::internalJSONNode(const json_string & unparsed) json_nothrow : _type(), _numtype(), _name(),_name_encoded(false), _string(unparsed), _string_encoded(), _value()
     initializeMutex(0)
     initializeRefCount(1)
     initializeFetch(false)
@@ -75,7 +75,7 @@ internalJSONNode::internalJSONNode(const json_string & unparsed) json_nothrow : 
 	   case JSON_TEXT(x)
 #endif
 
-internalJSONNode::internalJSONNode(const json_string & name_t, const json_string & value_t) json_nothrow : _type(), _name_encoded(), _name(JSONWorker::FixString(name_t, NAME_ENCODED)), _string(), _string_encoded(), _value()
+internalJSONNode::internalJSONNode(const json_string & name_t, const json_string & value_t) json_nothrow : _type(), _numtype(), _name(JSONWorker::FixString(name_t, NAME_ENCODED)), _name_encoded(), _string(), _string_encoded(), _value()
     initializeMutex(0)
     initializeRefCount(1)
     initializeFetch(false)
@@ -542,8 +542,8 @@ internalJSONNode::operator bool() const json_nothrow {
 				FetchNumber();
 		  }
 	   #endif /*<- */
-	   JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("as_int"));
-	   JSON_ASSERT(_value._number == (json_number)((json_int_t)_value._number), json_string(JSON_TEXT("as_int will truncate ")) + _string);
+	JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("as_int"));
+	JSON_ASSERT(std::fabs(_value._number - (json_number)((json_int_t)_value._number)) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("as_int will truncate ")) + _string);
 	   return (json_int_t)_value._number;
     }
 #else /*<- else */
@@ -603,7 +603,7 @@ internalJSONNode::operator bool() const json_nothrow {
 		  JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("(long)"));
 		  JSON_ASSERT(_value._number > LONG_MIN, _string + json_global(ERROR_LOWER_RANGE) + JSON_TEXT("long"));
 		  JSON_ASSERT(_value._number < LONG_MAX, _string + json_global(ERROR_UPPER_RANGE) + JSON_TEXT("long"));
-		  JSON_ASSERT(_value._number == (json_number)((long)_value._number), json_string(JSON_TEXT("(long) will truncate ")) + _string);
+		  JSON_ASSERT(std::fabs(_value._number - (json_number)((long)_value._number)) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("(long) will truncate ")) + _string);
 		  return (long)_value._number;
 	   #else /*<- else */
 		  JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("(long long)"));
@@ -618,7 +618,7 @@ internalJSONNode::operator bool() const json_nothrow {
 			 JSON_ASSERT(_value._number > LLONG_MIN, _string + json_global(ERROR_LOWER_RANGE) + JSON_TEXT("long long"));
 		  #endif
 
-		  JSON_ASSERT(_value._number == (json_number)((long long)_value._number), json_string(JSON_TEXT("(long long) will truncate ")) + _string);
+		  JSON_ASSERT(std::fabs(_value._number - (json_number)((long long)_value._number)) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("(long long) will truncate ")) + _string);
 		  return (long long)_value._number;
 	   #endif /*<- */
     }
@@ -644,7 +644,7 @@ internalJSONNode::operator bool() const json_nothrow {
 		  JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("(unsigned long)"));
 		  JSON_ASSERT(_value._number > 0, _string + json_global(ERROR_LOWER_RANGE) + JSON_TEXT("unsigned long"));
 		  JSON_ASSERT(_value._number < ULONG_MAX, _string + json_global(ERROR_UPPER_RANGE) + JSON_TEXT("unsigned long"));
-		  JSON_ASSERT(_value._number == (json_number)((unsigned long)_value._number), json_string(JSON_TEXT("(unsigend long) will truncate ")) + _string);
+		  JSON_ASSERT(std::fabs(_value._number - (json_number)((unsigned long)_value._number)) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("(unsigend long) will truncate ")) + _string);
 		  return (unsigned long)_value._number;
 	   #else /*<- else */
 		  JSON_ASSERT(type() == JSON_NUMBER, json_global(ERROR_UNDEFINED) + JSON_TEXT("(unsigned long long)"));
@@ -654,7 +654,7 @@ internalJSONNode::operator bool() const json_nothrow {
 		  #elif defined(ULLONG_MAX)
 			 JSON_ASSERT(_value._number < ULLONG_MAX, _string + json_global(ERROR_UPPER_RANGE) + JSON_TEXT("unsigned long long"));
 		  #endif
-		  JSON_ASSERT(_value._number == (json_number)((unsigned long long)_value._number), json_string(JSON_TEXT("(unsigned long long) will truncate ")) + _string);
+		  JSON_ASSERT(std::fabs(_value._number - (json_number)((unsigned long long)_value._number)) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("(unsigned long long) will truncate ")) + _string);
 		  return (unsigned long long)_value._number;
 	   #endif /*<- */
     }

--- a/_internal/Source/internalJSONNode.h
+++ b/_internal/Source/internalJSONNode.h
@@ -5,6 +5,10 @@
 #include "JSONChildren.h"
 #include "JSONMemory.h"
 #include "JSONGlobals.h"
+#include <cmath>
+#include <limits>
+#include <type_traits>
+#include <algorithm>
 #ifdef JSON_DEBUG
     #include <climits>  //to check int value
 #endif
@@ -80,7 +84,7 @@ class JSONNode;  //forward declaration
 
 class internalJSONNode {
 public:
-	LIBJSON_OBJECT(internalJSONNode);
+	LIBJSON_OBJECT(internalJSONNode)
     internalJSONNode(char mytype = JSON_NULL) json_nothrow json_hot;
     #ifdef JSON_READ_PRIORITY
 	   internalJSONNode(const json_string & unparsed) json_nothrow json_hot;
@@ -293,7 +297,7 @@ public:
     #endif
 };
 
-inline internalJSONNode::internalJSONNode(char mytype) json_nothrow : _type(mytype), _name(), _name_encoded(), _string(), _string_encoded(), _value()
+inline internalJSONNode::internalJSONNode(char mytype) json_nothrow : _type(static_cast<unsigned char>(mytype)), _numtype(), _name(), _name_encoded(), _string(), _string_encoded(), _value()
     initializeMutex(0)
     initializeRefCount(1)
     initializeFetch(true)
@@ -373,11 +377,37 @@ inline bool internalJSONNode::IsEqualTo(bool val) const json_nothrow {
     return val == _value._bool;
 }
 
+// Helper overloads picked by enable_if to avoid compiling both branches
+namespace {
+    template<typename T>
+    inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+    IsEqualToNum_impl(const internalJSONNode * node, T val) {
+        json_number lhs = static_cast<json_number>(val);
+        json_number rhs = node->_value._number;
+        json_number diff = std::fabs(lhs - rhs);
+        json_number eps = std::numeric_limits<json_number>::epsilon() * std::max<json_number>(static_cast<json_number>(1), std::fabs(rhs));
+        return diff <= eps;
+    }
+
+    template<typename T>
+    inline typename std::enable_if<!std::is_floating_point<T>::value, bool>::type
+    IsEqualToNum_impl(const internalJSONNode * node, T val) {
+        json_number n = node->_value._number;
+        json_number intpart = 0;
+        json_number frac = std::modf(n, &intpart);
+        json_number eps = std::numeric_limits<json_number>::epsilon() * std::max<json_number>(static_cast<json_number>(1), std::fabs(n));
+        if (std::fabs(frac) > eps) return false;
+        // ensure integer fits in T
+        if (intpart < static_cast<json_number>(std::numeric_limits<T>::min()) || intpart > static_cast<json_number>(std::numeric_limits<T>::max())) return false;
+        return static_cast<T>(intpart) == val;
+    }
+}
+
 template<typename T>
 inline bool internalJSONNode::IsEqualToNum(T val) const json_nothrow {
     if (type() != JSON_NUMBER) return false;
     Fetch();
-    return (json_number)val == _value._number;
+    return IsEqualToNum_impl<T>(this, val);
 }
 
 #ifdef JSON_REF_COUNT
@@ -460,12 +490,12 @@ inline JSONNode * internalJSONNode::at(json_index_t pos) json_nothrow {
     #endif
 
     #define IMP_SMALLER_INT_CAST_OP(_type, type_max, type_min)\
-	   inline internalJSONNode::operator _type() const json_nothrow {\
-		  JSON_ASSERT(_value._number > type_min, _string + json_global(ERROR_LOWER_RANGE) + JSON_TEXT(#_type));\
-		  JSON_ASSERT(_value._number < type_max, _string + json_global(ERROR_UPPER_RANGE) + JSON_TEXT(#_type));\
-		  JSON_ASSERT(_value._number == (json_number)((_type)(_value._number)), json_string(JSON_TEXT("(")) + json_string(JSON_TEXT(#_type)) + json_string(JSON_TEXT(") will truncate ")) + _string);\
-		  return (_type)static_cast<BASE_CONVERT_TYPE>(*this);\
-	   }
+		inline internalJSONNode::operator _type() const json_nothrow {\
+			JSON_ASSERT(_value._number > type_min, _string + json_global(ERROR_LOWER_RANGE) + JSON_TEXT(#_type));\
+			JSON_ASSERT(_value._number < type_max, _string + json_global(ERROR_UPPER_RANGE) + JSON_TEXT(#_type));\
+			JSON_ASSERT(std::fabs(_value._number - (json_number)((_type)(_value._number))) < JSON_FLOAT_THRESHHOLD, json_string(JSON_TEXT("(")) + json_string(JSON_TEXT(#_type)) + json_string(JSON_TEXT(") will truncate ")) + _string);\
+			return (_type)static_cast<BASE_CONVERT_TYPE>(*this);\
+		}
 
     IMP_SMALLER_INT_CAST_OP(char, CHAR_MAX, CHAR_MIN)
     IMP_SMALLER_INT_CAST_OP(unsigned char, UCHAR_MAX, 0)

--- a/_internal/Source/libjson.cpp
+++ b/_internal/Source/libjson.cpp
@@ -37,7 +37,7 @@
 		  return (json_char *)std::memcpy(json_malloc<json_char>(len), str.c_str(), len);
 	   #endif
     }
-	
+
 	inline json_char * alreadyCString(json_char * str) json_nothrow {
 		#ifdef JSON_MEMORY_MANAGE
 		   return (json_char *)json_global(STRING_HANDLER).insert(str);
@@ -275,13 +275,13 @@
 		#elif defined(JSON_MEMORY_CALLBACKS)
 			return MANAGER_INSERT(new(json_malloc<JSONNode>(1)) JSONNode(*((JSONNode*)orig)));
 		#else
-			return MANAGER_INSERT(new JSONNode(*((JSONNode*)orig)));
+			return MANAGER_INSERT(new JSONNode(*(reinterpret_cast<const JSONNode*>(orig))));
 		#endif
 	}
 
     JSONNODE * json_duplicate(json_const JSONNODE * orig){
 	   JSON_ASSERT_SAFE(orig, JSON_TEXT("null orig to json_duplicate"), return 0;);
-	   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow(((JSONNode*)orig) -> duplicate()));
+	   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow((reinterpret_cast<const JSONNode*>(orig)) -> duplicate()));
     }
 
     //assignment
@@ -309,75 +309,71 @@
     void json_set_n(JSONNODE * node, json_const JSONNODE * orig){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_set_n"), return;);
 	   JSON_ASSERT_SAFE(orig, JSON_TEXT("null node to json_set_n"), return;);
-	   *((JSONNode*)node) = *((JSONNode*)orig);
+	   *((JSONNode*)node) = *(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(orig)));
     }
 
 
     //inspectors
-    char json_type(json_const JSONNODE * node){
-	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_type"), return JSON_NULL;);
-	   return ((JSONNode*)node) -> type();
-    }
+	 char json_type(json_const JSONNODE * node){
+		 JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_type"), return JSON_NULL;);
+		 return static_cast<char>(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> type());
+	 }
 
-	char json_numtype(json_const JSONNODE * node){
-	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_type"), return JSON_NULL;);
-	   return ((JSONNode*)node) -> numtype();
-    }
+	 char json_numtype(json_const JSONNODE * node){
+		 JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_type"), return JSON_NULL;);
+		 return static_cast<char>(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> numtype());
+	 }
     json_index_t json_size(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_size"), return 0;);
-	   return ((JSONNode*)node) -> size();
+	   return const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> size();
     }
 
     json_bool_t json_empty(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_empty"), return true;);
-	   return (json_bool_t)(((JSONNode*)node) -> empty());
+	   return (json_bool_t)(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> empty());
     }
 
     json_char * json_name(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_name"), return toCString(EMPTY_CSTRING););
-	   return toCString(((JSONNode*)node) -> name());
+	   return toCString(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> name());
     }
 
     #ifdef JSON_COMMENTS
 	   json_char * json_get_comment(json_const JSONNODE * node){
 		  JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_get_comment"), return toCString(EMPTY_CSTRING););
-		  return toCString(((JSONNode*)node) -> get_comment());
+		  return toCString(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> get_comment());
 	   }
     #endif
 
     json_char * json_as_string(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_string"), return toCString(EMPTY_CSTRING););
-	   return toCString(((JSONNode*)node) -> as_string());
-	   //return toCString(static_cast<json_string>(*((JSONNode*)node)));
+	   return toCString(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> as_string());
     }
 
     json_int_t json_as_int(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_int"), return 0;);
-	   return ((JSONNode*)node) -> as_int();
-	   //return static_cast<json_int_t>(*((JSONNode*)node));
+	   return const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> as_int();
     }
 
     json_number json_as_float(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_float"), return 0.0f;);
-	   return ((JSONNode*)node) -> as_float();
-	   //return static_cast<json_number>(*((JSONNode*)node));
+	   return const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> as_float();
     }
 
     json_bool_t json_as_bool(json_const JSONNODE * node){
 	   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_bool"), return false;);
-	   return ((JSONNode*)node) -> as_bool();
-	   //return (json_bool_t)static_cast<bool>(*((JSONNode*)node));
+	   return const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> as_bool();
     }
 
 	#ifdef JSON_CASTABLE
 		JSONNODE * json_as_node(json_const JSONNODE * node){
 		   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_node"), return 0;);
-		   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow(((JSONNode*)node) -> as_node()));
+		   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow((reinterpret_cast<const JSONNode*>(node)) -> as_node()));
 		}
 
 		JSONNODE * json_as_array(json_const JSONNODE * node){
 		   JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_array"), return 0;);
-		   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow(((JSONNode*)node) -> as_array()));
+		   return MANAGER_INSERT(JSONNode::newJSONNode_Shallow((reinterpret_cast<const JSONNode*>(node)) -> as_array()));
 		}
 	#endif
 
@@ -400,7 +396,7 @@
     #ifdef JSON_BINARY
 	   void * json_as_binary(json_const JSONNODE * node, unsigned long * size){
 		  JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_as_binary"), if (size){*size = 0;} return 0;);
-		  return returnDecode64(((JSONNode*)node) -> as_binary(), size);
+		  return returnDecode64((reinterpret_cast<const JSONNode*>(node)) -> as_binary(), size);
 
 	   }
     #endif
@@ -424,12 +420,12 @@
     #ifdef JSON_WRITE_PRIORITY
 	   json_char * json_write(json_const JSONNODE * node){
 		  JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_write"), return toCString(EMPTY_CSTRING););
-		  return toCString(((JSONNode*)node) -> write());
+		  return toCString(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> write());
 	   }
 
 	   json_char * json_write_formatted(json_const JSONNODE * node){
 		  JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_write_formatted"), return toCString(EMPTY_CSTRING););
-		  return toCString(((JSONNode*)node) -> write_formatted());
+		  return toCString(const_cast<JSONNode*>(reinterpret_cast<const JSONNode*>(node)) -> write_formatted());
 	   }
     #endif
 
@@ -481,7 +477,7 @@
 	   void json_set_binary(JSONNODE * node, json_const void * data, unsigned long length){
 		  JSON_ASSERT_SAFE(node, JSON_TEXT("null node to json_swap"), return;);
 		  JSON_ASSERT_SAFE(data, JSON_TEXT("null data to json_set_binary"), *((JSONNode*)node) = EMPTY_CSTRING; return;);
-		  ((JSONNode*)node) -> set_binary((unsigned char *)data, (size_t)length);
+		  ((JSONNode*)node) -> set_binary(reinterpret_cast<unsigned char *>(const_cast<void *>(data)), static_cast<size_t>(length));
 	   }
     #endif
 

--- a/_internal/TestSuite/TestBinary.cpp
+++ b/_internal/TestSuite/TestBinary.cpp
@@ -5,10 +5,10 @@
     void TestSuite::TestBase64(void){
 	   UnitTest::SetPrefix("TestBinary.cpp - Base 64");
 
-	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"A", 1)), "A");
-	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"AB", 2)), "AB");
-	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABC", 3)), "ABC");
-	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCD", 4)), "ABCD");
+	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"A", 1)), "A");
+	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"AB", 2)), "AB");
+	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABC", 3)), "ABC");
+	   assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCD", 4)), "ABCD");
 	   #ifdef JSON_SAFE
           assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"", 0)), "");
 		  assertEquals(JSONBase64::json_decode64(JSON_TEXT("123!abc")), "");

--- a/_internal/TestSuite/UnitTest.cpp
+++ b/_internal/TestSuite/UnitTest.cpp
@@ -149,8 +149,8 @@ void UnitTest::SaveTo(const std::string & location){
 	   std::string html(ToHTML());
 	   fwrite(html.c_str(), html.length(), 1, fp);
 	   fclose(fp);
-	   system("pwd");
-		std::cout << "Saved file to " << location << std::endl;
+	   int status = system("pwd");
+		std::cout << "Saved file to " << location << "with status of " << status <<std::endl;
     } else {
         std::cout << "Couldn't save file" << std::endl;
     }

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -135,39 +135,7 @@ public:
 
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
-inline bool equals_json(const char* s1, const char* s2)
-{
-    return strcmp(s1, s2) == 0;
-}
-inline bool equals_json(const std::string* s1, const char* s2)
-{
-    return s1 && s2 && *s1 == s2;
-}
 
-inline bool equals_json(const char* s1, const std::string* s2)
-{
-    return s1 && s2 && s1 == *s2;
-}
-
-inline bool equals_json(const std::string*& s1, const std::string*& s2)
-{
-    return s1 == s2;
-}
-
-inline bool equals_json(const json_string*& s, json_number n)
-{
-    return atof(s->c_str()) == n;
-}
-
-inline bool equals_json(json_number n, const json_string*& s)
-{
-    return n == atof(s->c_str());
-}
-
-inline bool equals_json(json_number n1, json_number n2)
-{
-    return n1 == n2;
-}
 #define assertEquals(one, two)\
     assertTrue(equals_json(one,two))
 

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -156,22 +156,22 @@ public:
 
 
 #define assertEquals_Primitive(one, two)\
-    assertTrue_Primitive(static_cast<double>(one) == (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive(static_cast<json_number>(one) == (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertNotEquals_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<double>one) != (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive((static_cast<json_number>one) != (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertGreaterThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<double>one) > (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive((static_cast<json_number>one) > (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertGreaterThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<double>one) >= (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive((static_cast<json_number>one) >= (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertLessThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<double>one) < (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive((static_cast<json_number>one) < (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertLessThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<double>one) <= (static_cast<double>two), static_cast<double>one, static_cast<double>two)
+    assertTrue_Primitive((static_cast<json_number>one) <= (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
 
 #define assertNull(one)\
     assertTrue(one == NULL);

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <sstream>
 #include <cstring>
+#include "JSONDefs.h"
 
 #ifdef __GNUC__
     #define TEST_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -136,17 +136,27 @@ public:
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
 
+inline bool equals_json(const std::string* s1, const char* s2)
+{
+    return s1 && s2 && *s1 == s2;
+}
+
+inline bool equals_json(const char* s1, const std::string* s2)
+{
+    return s1 && s2 && s1 == *s2;
+}
+
 inline bool equals_json(const std::string*& s1, const std::string*& s2)
 {
     return s1 == s2;
 }
 
-inline bool equals_json(const json_string& s, json_number n)
+inline bool equals_json(const json_string*& s, json_number n)
 {
     return std::stod(s) == n;
 }
 
-inline bool equals_json(json_number n, const json_string& s)
+inline bool equals_json(json_number n, const json_string*& s)
 {
     return n == std::stod(s);
 }

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -264,3 +264,38 @@ inline bool equals_json(json_number n1, json_number n2)
     }
 
 #endif
+inline bool equals_json(const char* s1, const char* s2)
+{
+    if (!s1 || !s2) return s1 == s2;
+    return strcmp(s1, s2) == 0;
+}
+
+inline bool equals_json(const std::string& s1, const char* s2)
+{
+    return s2 && s1 == s2;
+}
+
+inline bool equals_json(const char* s1, const std::string& s2)
+{
+    return s1 && s1 == s2;
+}
+
+inline bool equals_json(const std::string& s1, const std::string& s2)
+{
+    return s1 == s2;
+}
+
+inline bool equals_json(const json_string& s, json_number n)
+{
+    return UnitTest::_floatsAreEqual(atof(s.c_str()), n);
+}
+
+inline bool equals_json(json_number n, const json_string& s)
+{
+    return UnitTest::_floatsAreEqual(n, atof(s.c_str()));
+}
+
+inline bool equals_json(json_number n1, json_number n2)
+{
+    return UnitTest::_floatsAreEqual(n1, n2);
+}

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -156,22 +156,26 @@ public:
 
 
 #define assertEquals_Primitive(one, two)\
-    assertTrue_Primitive(static_cast<json_number>(one) == (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive( \
+        static_cast<json_number>(one) == static_cast<json_number>(two), \
+        static_cast<json_number>(one), \
+         static_cast<json_number>(two) \
+    )
 
 #define assertNotEquals_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>one) != (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive((static_cast<json_number>(one)) != (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
 
 #define assertGreaterThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>one) > (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive((static_cast<json_number>(one)) > (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
 
 #define assertGreaterThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>one) >= (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive((static_cast<json_number>(one)) >= (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
 
 #define assertLessThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>one) < (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive((static_cast<json_number>(one)) < (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
 
 #define assertLessThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>one) <= (static_cast<json_number>two), static_cast<json_number>one, static_cast<json_number>two)
+    assertTrue_Primitive((static_cast<json_number>(one)) <= (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
 
 #define assertNull(one)\
     assertTrue(one == NULL);

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -135,7 +135,42 @@ public:
 
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
+/*
+inline bool equals_json(const char* s1, const char* s2)
+{
+    return strcmp(s1, s2) == 0;
+}
 
+inline bool equals_json(const std::string* s1, const char* s2)
+{
+    return s1 && s2 && *s1 == s2;
+}
+
+inline bool equals_json(const char* s1, const std::string* s2)
+{
+    return s1 && s2 && s1 == *s2;
+}
+
+inline bool equals_json(const std::string*& s1, const std::string*& s2)
+{
+    return s1 == s2;
+}
+
+inline bool equals_json(const json_string*& s, json_number n)
+{
+    return atof(s->c_str()) == n;
+}
+
+inline bool equals_json(json_number n, const json_string*& s)
+{
+    return n == atof(s->c_str());
+}
+
+inline bool equals_json(json_number n1, json_number n2)
+{
+    return n1 == n2;
+}
+*/
 #define assertEquals(one, two)\
     assertTrue(equals_json(one,two))
 
@@ -230,8 +265,6 @@ public:
 	   somet << something;\
 	   UnitTest::echo_(somet.str());\
     }
-
-#endif
 inline bool equals_json(const char* s1, const char* s2)
 {
     if (!s1 || !s2) return s1 == s2;
@@ -267,3 +300,5 @@ inline bool equals_json(json_number n1, json_number n2)
 {
     return UnitTest::_floatsAreEqual(n1, n2);
 }
+#endif
+

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -136,7 +136,7 @@ public:
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
 
-inline bool equals_json(const json_string& s1, const json_string& s2)
+inline bool equals_json(const std::string& s1, const std::string& s2)
 {
     return s1 == s2;
 }

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -135,7 +135,10 @@ public:
 
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
-
+inline bool equals_json(const char* s1, const char* s2)
+{
+    return strcmp(s1, s2) == 0;
+}
 inline bool equals_json(const std::string* s1, const char* s2)
 {
     return s1 && s2 && *s1 == s2;
@@ -153,12 +156,12 @@ inline bool equals_json(const std::string*& s1, const std::string*& s2)
 
 inline bool equals_json(const json_string*& s, json_number n)
 {
-    return std::stod(s) == n;
+    return atof(s) == n;
 }
 
 inline bool equals_json(json_number n, const json_string*& s)
 {
-    return n == std::stod(s);
+    return n == atof(s);
 }
 
 inline bool equals_json(json_number n1, json_number n2)

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -136,7 +136,7 @@ public:
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
 
-inline bool equals_json(const std::string& s1, const std::string& s2)
+inline bool equals_json(const std::string*& s1, const std::string*& s2)
 {
     return s1 == s2;
 }

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -156,12 +156,12 @@ inline bool equals_json(const std::string*& s1, const std::string*& s2)
 
 inline bool equals_json(const json_string*& s, json_number n)
 {
-    return atof(s) == n;
+    return atof(s->c_str()) == n;
 }
 
 inline bool equals_json(json_number n, const json_string*& s)
 {
-    return n == atof(s);
+    return n == atof(s->c_str());
 }
 
 inline bool equals_json(json_number n1, json_number n2)

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <sstream>
 #include <cstring>
-#include "JSONDefs.h"
 
 #ifdef __GNUC__
     #define TEST_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100)
@@ -135,83 +134,44 @@ public:
 
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
-/*
-inline bool equals_json(const char* s1, const char* s2)
-{
-    return strcmp(s1, s2) == 0;
-}
 
-inline bool equals_json(const std::string* s1, const char* s2)
-{
-    return s1 && s2 && *s1 == s2;
-}
-
-inline bool equals_json(const char* s1, const std::string* s2)
-{
-    return s1 && s2 && s1 == *s2;
-}
-
-inline bool equals_json(const std::string*& s1, const std::string*& s2)
-{
-    return s1 == s2;
-}
-
-inline bool equals_json(const json_string*& s, json_number n)
-{
-    return atof(s->c_str()) == n;
-}
-
-inline bool equals_json(json_number n, const json_string*& s)
-{
-    return n == atof(s->c_str());
-}
-
-inline bool equals_json(json_number n1, json_number n2)
-{
-    return n1 == n2;
-}
-*/
 #define assertEquals(one, two)\
-    assertTrue(equals_json(one,two))
+    assertTrue((one) == (two))
 
 #define assertNotEquals(one, two)\
-    assertTrue((static_cast<json_number>(one)) != (static_cast<json_number>(two)))
+    assertTrue((one) != (two))
 
 #define assertGreaterThan(one, two)\
-    assertTrue((static_cast<json_number>(one)) > (static_cast<json_number>(two)))
+    assertTrue((one) > (two))
 
 #define assertGreaterThanEqualTo(one, two)\
-    assertTrue((static_cast<json_number>(one)) >= (static_cast<json_number>(two)))
+    assertTrue((one) >= (two))
 
 #define assertLessThan(one, two)\
-    assertTrue((static_cast<json_number>(one)) < (static_cast<json_number>(two)))
+    assertTrue((one) < (two))
 
 #define assertLessThanEqualTo(one, two)\
-    assertTrue((static_cast<json_number>(one)) <= (static_cast<json_number>(two)))
+    assertTrue((one) <= (two))
 
 
 
 #define assertEquals_Primitive(one, two)\
-    assertTrue_Primitive( \
-        static_cast<json_number>(one) == static_cast<json_number>(two), \
-        static_cast<json_number>(one), \
-         static_cast<json_number>(two) \
-    )
+    assertTrue_Primitive((one) == (two), one, two)
 
 #define assertNotEquals_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>(one)) != (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
+    assertTrue_Primitive((one) != (two), one, two)
 
 #define assertGreaterThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>(one)) > (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
+    assertTrue_Primitive((one) > (two), one, two)
 
 #define assertGreaterThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>(one)) >= (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
+    assertTrue_Primitive((one) >= (two), one, two)
 
 #define assertLessThan_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>(one)) < (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
+    assertTrue_Primitive((one) < (two), one, two)
 
 #define assertLessThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((static_cast<json_number>(one)) <= (static_cast<json_number>(two)), static_cast<json_number>(one), static_cast<json_number>(two))
+    assertTrue_Primitive((one) <= (two), one, two)
 
 #define assertNull(one)\
     assertTrue(one == NULL);
@@ -252,8 +212,8 @@ inline bool equals_json(json_number n1, json_number n2)
 	   bool failed = false;\
 	   try {\
 		  code;\
-    } catch (const exc &){\
-        PASS(std::string(#exc) + " caught");\
+	   } catch (exc){\
+		  PASS(std::string(#exc) + " caught");\
 		  failed = true;\
 	   }\
 	   if (test_unlikely(!failed)){ FAIL(std::string(#exc) + " not caught");}\
@@ -265,40 +225,5 @@ inline bool equals_json(json_number n1, json_number n2)
 	   somet << something;\
 	   UnitTest::echo_(somet.str());\
     }
-inline bool equals_json(const char* s1, const char* s2)
-{
-    if (!s1 || !s2) return s1 == s2;
-    return strcmp(s1, s2) == 0;
-}
 
-inline bool equals_json(const std::string& s1, const char* s2)
-{
-    return s2 && s1 == s2;
-}
-
-inline bool equals_json(const char* s1, const std::string& s2)
-{
-    return s1 && s1 == s2;
-}
-
-inline bool equals_json(const std::string& s1, const std::string& s2)
-{
-    return s1 == s2;
-}
-
-inline bool equals_json(const json_string& s, json_number n)
-{
-    return UnitTest::_floatsAreEqual(atof(s.c_str()), n);
-}
-
-inline bool equals_json(json_number n, const json_string& s)
-{
-    return UnitTest::_floatsAreEqual(n, atof(s.c_str()));
-}
-
-inline bool equals_json(json_number n1, json_number n2)
-{
-    return UnitTest::_floatsAreEqual(n1, n2);
-}
 #endif
-

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -156,22 +156,22 @@ public:
 
 
 #define assertEquals_Primitive(one, two)\
-    assertTrue_Primitive((one) == (two), one, two)
+    assertTrue_Primitive(static_cast<double>(one) == (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertNotEquals_Primitive(one, two)\
-    assertTrue_Primitive((one) != (two), one, two)
+    assertTrue_Primitive((static_cast<double>one) != (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertGreaterThan_Primitive(one, two)\
-    assertTrue_Primitive((one) > (two), one, two)
+    assertTrue_Primitive((static_cast<double>one) > (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertGreaterThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((one) >= (two), one, two)
+    assertTrue_Primitive((static_cast<double>one) >= (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertLessThan_Primitive(one, two)\
-    assertTrue_Primitive((one) < (two), one, two)
+    assertTrue_Primitive((static_cast<double>one) < (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertLessThanEqualTo_Primitive(one, two)\
-    assertTrue_Primitive((one) <= (two), one, two)
+    assertTrue_Primitive((static_cast<double>one) <= (static_cast<double>two), static_cast<double>one, static_cast<double>two)
 
 #define assertNull(one)\
     assertTrue(one == NULL);

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -135,8 +135,27 @@ public:
 #define assertFloatEquals(one, two)\
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
 
+inline bool equals_json(const json_string& s1, const json_string& s2)
+{
+    return s1 == s2;
+}
+
+inline bool equals_json(const json_string& s, json_number n)
+{
+    return std::stod(s) == n;
+}
+
+inline bool equals_json(json_number n, const json_string& s)
+{
+    return n == std::stod(s);
+}
+
+inline bool equals_json(json_number n1, json_number n2)
+{
+    return n1 == n2;
+}
 #define assertEquals(one, two)\
-    assertTrue((static_cast<json_number>(one)) == (static_cast<json_number>(two)))
+    assertTrue(equals_jso(one,two))
 
 #define assertNotEquals(one, two)\
     assertTrue((static_cast<json_number>(one)) != (static_cast<json_number>(two)))

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -212,8 +212,8 @@ public:
 	   bool failed = false;\
 	   try {\
 		  code;\
-	   } catch (exc){\
-		  PASS(std::string(#exc) + " caught");\
+    } catch (const exc &){\
+        PASS(std::string(#exc) + " caught");\
 		  failed = true;\
 	   }\
 	   if (test_unlikely(!failed)){ FAIL(std::string(#exc) + " not caught");}\

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -136,22 +136,22 @@ public:
 	assertTrue(UnitTest::_floatsAreEqual(one, two))
 
 #define assertEquals(one, two)\
-    assertTrue((one) == (two))
+    assertTrue((static_cast<json_number>(one)) == (static_cast<json_number>(two)))
 
 #define assertNotEquals(one, two)\
-    assertTrue((one) != (two))
+    assertTrue((static_cast<json_number>(one)) != (static_cast<json_number>(two)))
 
 #define assertGreaterThan(one, two)\
-    assertTrue((one) > (two))
+    assertTrue((static_cast<json_number>(one)) > (static_cast<json_number>(two)))
 
 #define assertGreaterThanEqualTo(one, two)\
-    assertTrue((one) >= (two))
+    assertTrue((static_cast<json_number>(one)) >= (static_cast<json_number>(two)))
 
 #define assertLessThan(one, two)\
-    assertTrue((one) < (two))
+    assertTrue((static_cast<json_number>(one)) < (static_cast<json_number>(two)))
 
 #define assertLessThanEqualTo(one, two)\
-    assertTrue((one) <= (two))
+    assertTrue((static_cast<json_number>(one)) <= (static_cast<json_number>(two)))
 
 
 

--- a/_internal/TestSuite/UnitTest.h
+++ b/_internal/TestSuite/UnitTest.h
@@ -156,7 +156,7 @@ inline bool equals_json(json_number n1, json_number n2)
     return n1 == n2;
 }
 #define assertEquals(one, two)\
-    assertTrue(equals_jso(one,two))
+    assertTrue(equals_json(one,two))
 
 #define assertNotEquals(one, two)\
     assertTrue((static_cast<json_number>(one)) != (static_cast<json_number>(two)))

--- a/_internal/TestSuite/meson.build
+++ b/_internal/TestSuite/meson.build
@@ -1,0 +1,38 @@
+# Meson build for libjson TestSuite
+
+# Sources for the main TestSuite
+test_sources = [
+    'main.cpp',
+    'RunTestSuite2.cpp',
+    'TestAssign.cpp',
+    'TestBinary.cpp',
+    'TestChildren.cpp',
+    'TestComments.cpp',
+    'TestConverters.cpp',
+    'TestCtors.cpp',
+    'TestEquality.cpp',
+    'TestFunctions.cpp',
+    'TestInequality.cpp',
+    'TestInspectors.cpp',
+    'TestIterators.cpp',
+    'TestMutex.cpp',
+    'TestNamespace.cpp',
+    'TestRefCounting.cpp',
+    'TestSharedString.cpp',
+    'TestStreams.cpp',
+    'TestString.cpp',
+    'TestSuite.cpp',
+    'TestValidator.cpp',
+    'TestWriter.cpp',
+    'UnitTest.cpp',
+]
+
+# Build test binary linked against the libjson static library from this subproject
+libjson_tests = executable(
+    'libjson_testsuite',
+    test_sources,
+    include_directories: ['../Source', '../../'],
+    dependencies: [libjson_dep, libjson_tests2_dep],
+)
+
+test('libjson_testsuite', libjson_tests)

--- a/_internal/TestSuite2/BaseTest.h
+++ b/_internal/TestSuite2/BaseTest.h
@@ -9,7 +9,7 @@ class libjson_CodeCoverage;
 class BaseTest {
 public:
 	BaseTest(const std::string & name) : _name(name), coverage(0) {}
-	virtual ~BaseTest(void){};
+	virtual ~BaseTest(void){}
 	virtual void setUp(const std::string & methodName){ UnitTest::SetPrefix(_name + "::" + methodName); }
 	virtual void tearDown(void){}
 protected:

--- a/_internal/TestSuite2/JSON_Base64/json_encode64.cpp
+++ b/_internal/TestSuite2/JSON_Base64/json_encode64.cpp
@@ -9,19 +9,19 @@ void testJSON_Base64__json_encode64::testReverseEachOther(void){
         #ifdef JSON_SAFE
     		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"", 0)), "");
         #endif
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"A", 1)), "A");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"AB", 2)), "AB");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABC", 3)), "ABC");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCD", 4)), "ABCD");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDE", 5)), "ABCDE");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEF", 6)), "ABCDEF");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFG", 7)), "ABCDEFG");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGH", 8)), "ABCDEFGH");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGHI", 9)), "ABCDEFGHI");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGHIJ", 10)), "ABCDEFGHIJ");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGHIJK", 11)), "ABCDEFGHIJK");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGHIJKL", 12)), "ABCDEFGHIJKL");
-		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((unsigned char *)"ABCDEFGHIJKLM", 13)), "ABCDEFGHIJKLM");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"A", 1)), "A");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"AB", 2)), "AB");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABC", 3)), "ABC");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCD", 4)), "ABCD");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDE", 5)), "ABCDE");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEF", 6)), "ABCDEF");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFG", 7)), "ABCDEFG");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGH", 8)), "ABCDEFGH");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGHI", 9)), "ABCDEFGHI");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGHIJ", 10)), "ABCDEFGHIJ");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGHIJK", 11)), "ABCDEFGHIJK");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGHIJKL", 12)), "ABCDEFGHIJKL");
+		assertEquals(JSONBase64::json_decode64(JSONBase64::json_encode64((const unsigned char *)"ABCDEFGHIJKLM", 13)), "ABCDEFGHIJKLM");
 #endif
 }
 

--- a/_internal/TestSuite2/meson.build
+++ b/_internal/TestSuite2/meson.build
@@ -1,0 +1,41 @@
+# Meson build for libjson TestSuite2
+
+test2_sources = [
+    '../TestSuite/UnitTest.cpp',
+    # JSON_Base64
+    'JSON_Base64/json_encode64.cpp',
+    'JSON_Base64/json_decode64.cpp',
+    # NumberToString
+    'NumberToString/getLenSize.cpp',
+    'NumberToString/isNumeric.cpp',
+    'NumberToString/_uitoa.cpp',
+    'NumberToString/_itoa.cpp',
+    'NumberToString/_ftoa.cpp',
+    'NumberToString/_atof.cpp',
+    'NumberToString/_areFloatsEqual.cpp',
+    # JSONValidator
+    'JSONValidator/securityTest.cpp',
+    'JSONValidator/isValidString.cpp',
+    'JSONValidator/isValidRoot.cpp',
+    'JSONValidator/isValidPartialRoot.cpp',
+    'JSONValidator/isValidObject.cpp',
+    'JSONValidator/isValidNumber.cpp',
+    'JSONValidator/isValidNamedObject.cpp',
+    'JSONValidator/isValidMember.cpp',
+    'JSONValidator/isValidArray.cpp',
+    # JSONDebug / JSONGlobals
+    'JSONDebug/JSON_ASSERT.cpp',
+    'JSONDebug/JSON_ASSERT_SAFE.cpp',
+    'JSONDebug/JSON_FAIL_SAFE.cpp',
+    'JSONDebug/JSON_FAIL.cpp',
+    'JSONGlobals/jsonSingleton.cpp',
+]
+
+libjson_tests2 = static_library(
+    'libjson_testsuite2',
+    test2_sources,
+    include_directories: ['../Source', '../../'],
+    dependencies: [libjson_dep],
+)
+
+libjson_tests2_dep = declare_dependency(link_with: libjson_tests2, include_directories: ['../Source', '../../'])

--- a/libjson.h
+++ b/libjson.h
@@ -39,9 +39,9 @@
 		  #endif
 		  json_char * json_strip_white_space(json_const json_char * json);
 		  #ifdef JSON_VALIDATE
-			 //#ifdef JSON_DEPRECATED_FUNCTIONS
-			//	JSONNODE * json_deprecated(json_validate(json_const json_char * json), "json_validate is deprecated, use json_is_valid and json_parse instead");
-			// #endif
+			 #ifdef JSON_DEPRECATED_FUNCTIONS
+				JSONNODE * json_deprecated(json_validate(json_const json_char * json), "json_validate is deprecated, use json_is_valid and json_parse instead");
+			 #endif
 			 json_bool_t json_is_valid(json_const json_char * json);
 			 json_bool_t json_is_valid_unformatted(json_const json_char * json);
 		  #endif
@@ -190,7 +190,7 @@
 	#include <cwchar>  /* need wide characters */
 	#include <string>
 
-    namespace libjson {	   
+    namespace libjson {
 	   #ifdef JSON_EXPOSE_BASE64
 		  inline static json_string encode64(const unsigned char * binary, size_t bytes) json_nothrow {
 			 return JSONBase64::json_encode64(binary, bytes);
@@ -200,38 +200,38 @@
 			 return JSONBase64::json_decode64(encoded);
 		  }
 	   #endif
-	   
+
 	   //useful if you have json that you don't want to parse, just want to strip to cut down on space
 	   inline static json_string strip_white_space(const json_string & json) json_nothrow {
 		  return JSONWorker::RemoveWhiteSpaceAndComments(json, false);
 	   }
-		
+
 		#ifndef JSON_STRING_HEADER
 			inline static std::string to_std_string(const json_string & str){
 				#if defined(JSON_UNICODE) ||defined(JSON_MEMORY_CALLBACKS) || defined(JSON_MEMORY_POOL)
-					return std::string(str.begin(), str.end());		
+					return std::string(str.begin(), str.end());
 				#else
 					return str;
 				#endif
 			}
 			inline static std::wstring to_std_wstring(const json_string & str){
 				#if (!defined(JSON_UNICODE)) || defined(JSON_MEMORY_CALLBACKS) || defined(JSON_MEMORY_POOL)
-					return std::wstring(str.begin(), str.end());		
+					return std::wstring(str.begin(), str.end());
 				#else
 					return str;
 				#endif
 			}
-			
+
 			inline static json_string to_json_string(const std::string & str){
 				#if defined(JSON_UNICODE) ||defined(JSON_MEMORY_CALLBACKS) || defined(JSON_MEMORY_POOL)
-					return json_string(str.begin(), str.end());		
+					return json_string(str.begin(), str.end());
 				#else
 					return str;
 				#endif
 			}
 			inline static json_string to_json_string(const std::wstring & str){
 				#if (!defined(JSON_UNICODE)) || defined(JSON_MEMORY_CALLBACKS) || defined(JSON_MEMORY_POOL)
-					return json_string(str.begin(), str.end());		
+					return json_string(str.begin(), str.end());
 				#else
 					return str;
 				#endif

--- a/meson.build
+++ b/meson.build
@@ -1,83 +1,320 @@
-#-------------------------------------#
-#  This is the meson file             #
-#-------------------------------------#
 
-project('libjson', 'cpp')
 
-# Configuration
+project('libjson', 'cpp', license: 'LicenseRef-Jonathan-Wallace-BSD-2-Clause-Variant', version: '7.6.2',
+    default_options: ['b_ndebug=if-release', 'b_staticpic=true', 'b_pie=true', 'warning_level=2'])
 
-# adds c compiler
 cpp = meson.get_compiler('cpp')
 cpp_version = cpp.version()
 
 machine = target_machine.system()
 architecture = target_machine.cpu_family()
 
+incdir = include_directories('_internal/Source', '.')
 
-# Targets
-libname = 'json'
-#major_version = '7'
-#minor_version = '6.1'
+#TODO: Check meson buildtype to set the flags below instead of using custom options
+# cxxflags_default = release
+# cxxflags_shared should be applied only when building the shared library which is handled below
+# cxxflags_small is the same as meson's minsize
+# cxxflags_debug is debug
+# the -DNDEBUG should be changed to meson's b_ndebug option and probably set to if-release. Maybe also for the minsize target.
 
+# Defaults: per-buildtype flags are derived from Meson `buildtype` option.
+# Avoid forcing -DNDEBUG or -fPIC here; Meson controls those via `b_ndebug` and `b_staticpic`.
 
-incdir = ['_internal/Source','./']
-objdir = 'Objects'
-
-# Defaults
-cxxflags_default = ['-O3', '-ffast-math', '-fexpensive-optimizations', '-DNDEBUG']
-cxxflags_shared = ['-fPIC']
-cxxflags_small = ['-Os', '-ffast-math', '-DJSON_LESS_MEMORY', '-DNDEBUG', '-fPIC']
-cxxflags_debug = ['-g', '-DJSON_SAFE', '-DJSON_DEBUG', '-fPIC']
-
-
-if cpp.get_id().contains('gcc')
-  if cpp.version().version_compare('<5.0')
-    if cpp.has_argument('-std=gnu++11')
-      # Add this argument to the list since C++11 is a minimum required C++ compiler standard
-      add_project_arguments('-std=gnu++11', language: 'cpp')
-    else
-      error('C++11/GNU++11 standard is required but was not able to be set!')
-    endif
-  endif
-endif
-
-# Adjustments based on OS
-if machine == 'darwin'
-    cxxflags_default += ['-fast']
-else
-    cxxflags_default += ['-fPIC']
-endif
-
-
-# This is for cpp arguments
+# Keep a small set of project-specific flags per buildtype.
 cpp_args = []
 
-# Adjustments based on architecture
-if architecture == 'x86_32'
-    cpp_args += ['-m32']
+# Ensure older GCC compilers get gnu++11 if they don't default to C++11
+if cpp.get_id().contains('gcc')
+    if cpp.version().version_compare('<5.0')
+        if cpp.has_argument('-std=gnu++11')
+            # Apply project-local C++11 flag for old compilers only
+            add_project_arguments('-std=gnu++11', language: 'cpp')
+        else
+            error('C++11/GNU++11 standard is required but was not able to be set!')
+        endif
+    endif
 endif
 
-# Build type specific flags
-#build_type = get_option('build_type')
-#if build_type == 'small'
-    cpp_args += cxxflags_small
-#elif build_type == 'debug'
-    cpp_args += cxxflags_debug
-#else
-    cpp_args += cxxflags_default
-#endif
+# Build-type specific flags
+buildtype = get_option('buildtype')
+if buildtype == 'debug'
+    if get_option('json_safe').disabled()
+        # This is always turned on for debug builds.
+        cpp_args += ['-DJSON_SAFE']
+    endif
+    cpp_args += ['-DJSON_DEBUG']
+elif buildtype == 'minsize'
+    cpp_args += ['-ffast-math', '-DJSON_LESS_MEMORY']
+else
+    # release, debugoptimized, or other
+    cpp_args += ['-ffast-math', '-fexpensive-optimizations']
+endif
 
-# Shared library settings
-#shared = get_option('shared')
+warning_flags = []
+linker_flags = []  #additional linker flags to add per-compiler for hardening.
 
-#lib_target = libname + '.' + (shared ? 'so' : 'a')
+if cpp.get_id().contains('gcc') or cpp.get_id().contains('clang')
+    #TODO: Add -Wcast-align=strict and fix these issues to help ensure better portability
+    #NOTE: -Wsign-conversion can be useful while debugging, but there are numerous places this shows up
+    #      and it is not useful, so only add it while debugging.
+    #NOTE: 4/4/2024 - adding flags from https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++
+    warning_flags = [
+        #	'-Wcast-align=strict',
+        '-Wshadow=compatible-local',
+        '-Wvla',
+        '-Wfloat-equal',
+        '-Wnull-dereference',
+        '-Wunused-const-variable',
+        '-Wunused-parameter',
+        '-Wunused-value',
+        '-Wduplicated-cond',
+        '-Wjump-misses-init',
+        '-Wstringop-overflow',
+        '-Wlogical-op',
+        '-Wshift-overflow',
+        '-Wshift-overflow=1',
+        '-Wshift-overflow=2',
+        '-Wdouble-promotion',
+        '-Wformat-security',
+        '-Wold-style-definition',
+        '-Wstrict-prototypes',
+        '-Wmissing-declarations',
+        '-Wmissing-prototypes',
+        '-Wchar-subscripts',
+        '-Wundef',
+        '-Wformat',
+        '-Wformat=2',
+        '-Wint-conversion',  #-Warith-conversion
+        '-Wenum-conversion',
+        '-Wfloat-conversion',
+        '-Wint-to-pointer-cast',
+        '-Wimplicit-fallthrough',
+        '-D_GLIBCXX_ASSERTIONS',
+        '-fstrict-flex-arrays=3',
+        '-fno-delete-null-pointer-checks',
+        '-fno-strict-overflow',
+        '-fno-strict-aliasing',
+        '-ftrivial-auto-var-init=zero',
+        '-Wtrampolines',  #GCC only at this time
+        '-Wincompatible-pointer-types-discards-qualifiers',
+        '-Woverlength-strings',
+        '-Wnewline-eof',
+        '-Wno-c23-extensions',  #We do not want this warning since we are already checking for when C23 extensions are available before we use them. If not, we use a compiler specific definition, or make it an empty definition.
+        '-Wparentheses',
+        '-Wextra-semi',
+        '-Wcast-qual',
+        '-Werror=sometimes-uninitialized',
+        '-Wuninitialized',
+        '-Wunevaluated-expression',
+        '-Wunsequenced',
+        '-Wvarargs',
+        '-Wwrite-strings',
+        '-Wrestrict',
+        '-Wstringop-truncation',
+        '-Werror=trigraphs',
+        '-Wunreachable-code',
+        '-Wcomment',
+        '-Wsequence-point',
+        '-Wreturn-type',
+        '-Wpointer-bool-conversion',
+        '-Wmismatched-dealloc',
+        '-Wfree-nonheap-object',
+        '-fnullability',
+        '-Wnullability',  # Warnings for nullability annotations
+        '-Wnullability-completeness',  # Warn if nullability annotations are incomplete
+        '-Wnullability-completeness-on-arrays',  # Warn if nullability annotations are incomplete
+        # '-Wnullable-to-nonnull-conversion', # Basically warns so you have to cast to the correct nullability type. Not needed today -TJE
+        '-Wswitch-enum',
+        '-Walloc-zero',
+        '-Walloc-size',
+        '-Wcalloc-transposed-args',
+        '-Werror=alloca',  # Do not allow use of the alloca function
+        '-Wstring-compare',  # Helps detect when strcmp is used when the programmer likely meant to use strncmp
+    ]
 
-#libdir = join_paths(get_option('prefix'), 'lib')
+    if cpp.get_id().contains('gcc') and cpp.version().version_compare('>=10.0')
+        #only enable the sign conversion warning on versions 10 and up because it is way too noisy on earlier GCC versions than it is useful-TJE
+        warning_flags += '-Wsign-conversion'
+    endif
 
-#includedir = join_paths(get_option('prefix'), 'include', libname)
+    if target_machine.system() != 'sunos'
+        warning_flags += '-fstack-protector-strong'
+    else
+        #Illumos will support this, but solaris will not due to library differences in the systems
+        if meson.version().version_compare('>=1.2.0')
+            if target_machine.kernel() == 'illumos'
+                warning_flags += '-fstack-protector-strong'
+            endif
+        else
+            # TODO: Backup method to detect illumos vs solaris
+        endif
+    endif
 
-# Targets
-#objs = []
+    if cpp.get_id().contains('gcc') and target_machine.system() == 'windows'
+        #According to the link below, this is not needed in Windows...it also causes a bug in some versions of GCC for Windows.
+        #https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+        #NOTE: While this appears to be fixed for versions 11 and 12, the current CI is failing on this with
+        #      version 12.2. If we want to or need to enable this, it should be done based on which versions we
+        #      know have been patched for this. -TJE
+    else
+        warning_flags += '-fstack-clash-protection'
+    endif
+
+    if target_machine.cpu_family() == 'ppc64'
+        #power pc builds generate a lot of warnings/notes about ABI changes since GCC-5
+        #this flag is disabling them because this is way too noisy.
+        warning_flags += ['-Wno-psabi']
+    elif target_machine.cpu_family() == 'x86_64'
+        warning_flags += ['-fcf-protection=full']        #this may be linux only at this time.
+    elif target_machine.cpu_family() == 'aarch64'
+        warning_flags += ['-mbranch-protection=standard']
+    endif
+
+    linker_flags += ['-Wl,-z,noexecstack', '-Wl,-z,relro', '-Wl,-z,now']
+
+    #test if setting _FORTIFY_SOURCE higher than default generates a warning
+    #this issue showed up on Rocky Linux 8 and we don't want to generate extra noise
+    #due to trying to follow openssf best practices
+    fortifytest = ''' #include <stdio.h>
+                      int main() {
+                          return 0;
+                      }
+                  '''
+    fortifyresult = cpp.compiles(
+        fortifytest,
+        name: 'Set _FORTIFY_SOURCE to highest possible level without warnings',
+        args: ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=5', '-Werror'],
+    )
+    if fortifyresult == true
+        warning_flags += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
+    endif
+
+elif cpp.get_id().contains('msvc')
+    #See here for enabling/disabling msvc warnings:
+    #https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level?view=msvc-170
+    #warnings off by default: https://learn.microsoft.com/en-us/cpp/preprocessor/compiler-warnings-that-are-off-by-default?view=msvc-170
+    warning_flags = [
+        #Turn off the following warnings. If using /wall in Windows, many of these show all over the Windows API
+        #This is likely not an issue with meson, but matching VS project files for now
+        '/wd4214',  # nonstandard extension used : bit field types other than int
+        '/wd4201',  # nonstandard extension used : nameless struct/union
+        '/wd4668',  # 'symbol' is not defined as a preprocessor macro, replacing with '0' for 'directives'. While like -Wundef, this creates too many warnings in system headers to use
+        '/wd4820',  # 'bytes' bytes padding added after construct 'member_name'
+        '/wd4710',  # 'function' : function not inlined
+        '/wd5045',  # Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
+        '/wd4711',  # function 'function' selected for inline expansion
+        '/wd4324',  # 'struct_name' : structure was padded due to __declspec(align())
+        '/wd4221',  # nonstandard extension used : 'identifier' : cannot be initialized using address of automatic variable
+        '/wd4204',  # nonstandard extension used : non-constant aggregate initializer
+        '/wd5105',  # macro expansion producing 'defined' has undefined behavior
+        '/wd4746',  # volatile access of '<expression>' is subject to /volatile:[iso|ms] setting; consider using __iso_volatile_load/store intrinsic functions.
+        #Turn on the following warnings to make the output more useful or like GCC/clang
+        '/w14255',  # 'function' : no function prototype given: converting '()' to '(void)'
+        '/w14062',  # enumerator 'identifier' in switch of enum 'enumeration' is not handled
+        '/w14101',  # 'identifier' : unreferenced local variable
+        '/w14189',  # 'identifier' : local variable is initialized but not referenced
+        '/w15031',  # #pragma warning(pop): likely mismatch, popping warning state pushed in different file
+        '/w15032',  # detected #pragma warning(push) with no corresponding #pragma warning(pop)
+        '/w15262',  # implicit fall-through occurs here; are you missing a break statement? Use [[fallthrough]] when a break statement is intentionally omitted between cases
+        '/w14255',  # 'function' : no function prototype given: converting '()' to '(void)' #NOTE: Only needed for /Wall, otherwise enabling can be good-TJE
+        '/w14242',  # identifier conversion from type 1 to type 2, possible loss of data (matches -wconversion above)
+        '/w14254',  # operator conversion from type 1 to type 2, possible loss of data (matches -wconversion above)
+        '/w14287',  # operator: unsigned/negative constant mismatch (matches -wconversion above)
+        '/w14296',  # operator: expression is always false
+        '/w14365',  # action: conversion from type 1 to type 2, signed/unsigned mismatch (matches -wconversion above)
+        '/w14388',  # implicit conversion warning during a comparison (matches -wconversion above)
+        '/w14545',  # expression before comma evaluates to a function which is missing an argument list
+        '/w14546',  # function call before comma missing argument list
+        '/w14547',  # 'operator' : operator before comma has no effect; expected operator with side-effect
+        '/w14548',  # expression before comma has no effect; expected expression with side-effect
+        '/w14549',  # 'operator1': operator before comma has no effect; did you intend 'operator2'?
+        '/w14574',  # 'identifier' is defined to be '0': did you mean to use '#if identifier'?
+        '/w14605',  # 	'/Dmacro' specified on current command line, but was not specified when precompiled header was built
+        '/w14555',  # expression has no effect; expected expression with side-effect
+        '/w14774',  # 'string' : format string expected in argument number is not a string literal
+        '/w14777',  # 'function' : format string 'string' requires an argument of type 'type1', but variadic argument number has type 'type2'
+        '/w14826',  # Conversion from 'type1' to 'type2' is sign-extended. This may cause unexpected runtime behavior (more -wconversion)
+        '/w15219',  # implicit conversion from 'type-1' to 'type-2', possible loss of data (-wconversion)
+        '/w15240',  # 'attribute-name': attribute is ignored in this syntactic position
+        '/w15245',  # 'function': unreferenced function with internal linkage has been removed
+        '/w14555',  # expression has no effect; expected expression with side-effect
+        '/w15264',  # 'variable-name': 'const' variable is not used
+        '/w24302',  # 'conversion': truncation from 'type1' to 'type2'
+        '/w14311',  # 'variable': pointer truncation from 'type' to 'type'
+        '/w14312',  # 'operation': conversion from 'type1' to 'type2' of greater size
+        '/w14319',  # 'operator': zero extending 'type1' to 'type2' of greater size
+        '/w14702',  # warning for unreachable code
+        #Treat the following as errors
+        '/we4431',  # missing type specifier - int assumed. Note: C no longer supports default-int
+        '/we4905',  # wide string literal cast to 'LPSTR'
+        '/we4906',  # string literal cast to 'LPWSTR'
+        '/we4837',  # trigraph detected: '??character' replaced by 'character'
+        '/we4628',  # digraphs not supported with -Ze. Character sequence 'digraph' not interpreted as alternate token for 'char'
+        '/we4289',  # nonstandard extension used : 'var' : loop control variable declared in the for-loop is used outside the for-loop scope
+        '/we4464',  # relative include path contains '..'
+        '/GS',  #security cookie for stack protection
+        '/sdl',  #adds recommended security development lifecycle checks
+        '/Qspectre',
+        '/guard:cf',  #control flow guard
+        '/d2guard4',  #control flow guard
+    ]
+
+    if target_machine.cpu_family() == 'x86_64' or target_machine.cpu_family() == 'x86'
+        # https://learn.microsoft.com/en-us/cpp/build/reference/qintel-jcc-erratum?view=msvc-170
+        warning_flags += '/QIntel-jcc-erratum'
+    endif
+
+    linker_flags += [
+        '/guard:cf',  #control flow guard
+        '/SafeSEH',  #on by default in x64 so it is unrecognized otherwise.
+        '/NXCOMPAT',  #data execution prevention
+        '/dynamicbase',  #address space randomization
+    ]
+
+    #TODO: check compiler version to handle warnings that were off by default in earlier versions
+    #ex: C4431 (level 4)	missing type specifier - int assumed. Note: C no longer supports default-int
+    #    This was off by default in compilers before VS2012.
+elif cpp.get_id().contains('xlc')
+    #This section is for IBM's xlc compiler and warning options it may need.
+    #NOTE: xlcclang should be handled above
+    #See following links:
+    #https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=reference-supported-xl-compiler-options-by-different-invocations
+    #https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=end-mapping-legacy-xl-compiler-options-gcc-options
+    #https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=reference-individual-xl-compiler-option-descriptions
+    warning_flags = []
+endif
+
+add_project_arguments(cpp.get_supported_arguments(warning_flags), language: 'cpp')
+add_project_link_arguments(cpp.get_supported_link_arguments(linker_flags), language: 'cpp')
+
+
+# Platform-specific adjustments (example: darwin fast flag for release builds)
+if machine == 'darwin' and buildtype != 'debug'
+    cpp_args += ['-fast']
+endif
+
+# Project option: json_safe
+if get_option('json_safe').enabled()
+    cpp_args += ['-DJSON_SAFE']
+endif
+
+# Adjustments based on architecture
+# This ad-hoc architecture logic is commented out in favor of a proper native/cross file.
+# Example native-file snippet to force 32-bit toolchain (pass with `meson --native-file=my32.native`):
+# [binaries]
+# c = '/usr/bin/gcc'
+# cpp = '/usr/bin/g++'
+# and include -m32 via the compiler invocation if needed.
+# Example cross-file snippet (host_machine):
+# [host_machine]
+# cpu_family = 'x86'
+# cpu = 'i686'
+# endian = 'little'
+# The following ad-hoc logic is intentionally disabled:
+# if architecture == 'x86_32'
+#     cpp_args += ['-m32']
+# endif
 
 common_sources = [
     '_internal/Source/internalJSONNode.cpp',
@@ -92,10 +329,18 @@ common_sources = [
     '_internal/Source/JSONStream.cpp',
     '_internal/Source/JSONValidator.cpp',
     '_internal/Source/JSONWorker.cpp',
-   '_internal/Source/JSONWriter.cpp',
-    '_internal/Source/libjson.cpp'
+    '_internal/Source/JSONWriter.cpp',
+    '_internal/Source/libjson.cpp',
 ]
 
+# TODO: Handle when passed building static versus dynamic library. Do not allow the "both" option.
 
-libjson = static_library('libjson', common_sources, c_args: cpp_args,include_directories : incdir)
-libjson_dep = declare_dependency(link_with : libjson, include_directories : incdir)
+
+libjson = static_library('libjson', common_sources, cpp_args: cpp_args, include_directories: incdir)
+libjson_dep = declare_dependency(link_with: libjson, include_directories: incdir)
+
+# Gate legacy test suites with a project option in meson_options.txt
+if get_option('enable_legacy_tests')
+    subdir('_internal/TestSuite2')
+    subdir('_internal/TestSuite')
+endif

--- a/meson.format
+++ b/meson.format
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MPL-2.0
+# see https://mesonbuild.com/Commands.html#format
+max_line_length = 120
+indent_by = '    '
+space_array = false
+kwargs_force_multiline = false
+wide_colon = false
+no_single_comma_function = false
+end_of_line = 'native'
+indent_before_comments = '  '
+simplify_string_literals = true
+insert_final_newline = true
+tab_width = 4
+sort_files = true
+group_arg_value = false
+# Note: Rules should match between .editorconfig and meson.format
+use_editor_config = true

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,9 @@
+option('enable_legacy_tests',
+       type : 'boolean',
+       value : true,
+       description : 'Enable legacy internal test suites')
+
+option('json_safe',
+       type : 'feature',
+       value : 'enabled',
+       description : 'Enable JSON_SAFE build behavior (adds -DJSON_SAFE)')


### PR DESCRIPTION
Fixing all the sign conversion, undef, etc warnings in libjson.

There were a lot of warnings coming from this code in modern compilers.
All changes are C++11 compatible and resolve all warnings  in GCC 15.2.1

I also added the test suite into meson as something that can be run.
While it runs, meson does not understand the output correctly so running `meson test` produces an incorrect result saying everything passes. The old test code writes it's own HTML style output file which you need to open to check the results.

The meson.build was also updated to be more proper meson rather than cheap and quick makefile conversion.
So it sets all compiler flags/options for each built type (release/debug/etc) the way the makefile would, but according to meson's rules/options.
I also upped the warning level to 2 and added in the hardening related options from our other opensea-libraries.

I did not get a chance to try upgrading that, so that should be a feature for the next person 😄 